### PR TITLE
(Horizontal) Tab character (U+0009) should be allowed

### DIFF
--- a/props/package.props
+++ b/props/package.props
@@ -11,17 +11,19 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package config">
-    <PackageVersion>0.0.3</PackageVersion>
-    <AssemblyVersion>0.0.3</AssemblyVersion>
+    <PackageVersion>0.0.3.1</PackageVersion>
+    <AssemblyVersion>0.0.3.1</AssemblyVersion>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>
-      v0.0.3
-      - QW0004: Characters with Trojan Horse potential are not allowed
-      v0.0.2
-      - QW0003: Decorate pure functions
-      v0.0.1
-      - QW0001: Use a testable time provider
-      - QW0002: Parse() throws
+v0.0.3.1
+- QW0004: Horizontal tab (U+9, \t) is allowed too (#6)
+v0.0.3
+- QW0004: Characters with Trojan Horse potential are not allowed
+v0.0.2
+- QW0003: Decorate pure functions
+v0.0.1
+- QW0001: Use a testable time provider
+- QW0002: Parse() throws
     </PackageReleaseNotes>
     <PackageProjectUrl>http://www.github.com/Qowaiv/qowaiv-analyzers</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/specs/Qowaiv.CodeAnalysis.CSharp.Specs/TrojanCharactersAreNotAllowed_specs.cs
+++ b/specs/Qowaiv.CodeAnalysis.CSharp.Specs/TrojanCharactersAreNotAllowed_specs.cs
@@ -9,6 +9,10 @@ public class Verify
         .AddSource(@"Cases/TrojanCharactersAreNotAllowed.cs")
         .Verify();
 
+    [TestCase('\t', "horizontal tab")]
+    public void NoVulnerability(char ch, string message)
+         => NoVulnerability(ch, ch, message);
+
     [TestCase(0x00020, 0x0007E, "ASCII - space ... ~")]
     [TestCase(0x00600, 0x006FF, "Arabic")]
     [TestCase(0x00750, 0x0077F, "Arabic Supplement")]

--- a/src/Qowaiv.CodeAnalysis/Rules/TrojanCharactersAreNotAllowed.cs
+++ b/src/Qowaiv.CodeAnalysis/Rules/TrojanCharactersAreNotAllowed.cs
@@ -45,7 +45,8 @@ public partial class TrojanCharactersAreNotAllowed : DiagnosticAnalyzer
         || cat == UnicodeCategory.OtherNotAssigned;
 
     private static bool InAllowedRange(int utf32)
-        => Arabic.Contains(utf32)
+        => utf32 == '\t'
+        || Arabic.Contains(utf32)
         || ArabicExtendedA.Contains(utf32)
         || ArabicExtendedB.Contains(utf32)
         || ArabicPresentationFormsA.Contains(utf32)


### PR DESCRIPTION
Its a control character that should be allowed (obviously).