### PR TITLE
Reduce the visual impact of reporting on QW0003

### DIFF
--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DecorateFunctions.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DecorateFunctions.cs
@@ -6,11 +6,12 @@ using FluentAssertions;
 public class Noncompliant
 {
     public int PureFunction() => 42; // Noncompliant {{Decorate this method with a [Pure] or [Impure] attribute.}}
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //         ^^^^^^^^^^^^
+    
     public int PureFunction(int scale) => scale * 42; // Noncompliant
 
     [Other]
-    public int DecoratedOtherwise() => 42; // Noncompliant@-1
+    public int DecoratedOtherwise() => 42; // Noncompliant
 }
 
 public class Compliant

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext.cs
@@ -1,9 +1,9 @@
 ﻿namespace Microsoft.CodeAnalysis.Diagnostics;
 
 /// <summary>Extensions on <see cref="SyntaxNodeAnalysisContext"/>.</summary>
-public static class SyntaxNodeAnalysisContextExtensions
+internal static class SyntaxNodeAnalysisContextExtensions
 {
-    /// <summary>Report a <see cref="Diagnostic"/> about a  <see cref="SyntaxNode"/>'.</summary>
+    /// <summary>Report a <see cref="Diagnostic"/> about a <see cref="SyntaxNode"/>'.</summary>
     public static void ReportDiagnostic(
         this SyntaxNodeAnalysisContext context,
         DiagnosticDescriptor descriptor,
@@ -13,5 +13,17 @@ public static class SyntaxNodeAnalysisContextExtensions
             Diagnostic.Create(
                 descriptor,
                 node.GetLocation(),
+                messageArgs));
+
+    /// <summary>Report a <see cref="Diagnostic"/> about a <see cref="SyntaxToken"/>'.</summary>
+    public static void ReportDiagnostic(
+        this SyntaxNodeAnalysisContext context,
+        DiagnosticDescriptor descriptor,
+        SyntaxToken token,
+        params object[] messageArgs)
+        => context.ReportDiagnostic(
+            Diagnostic.Create(
+                descriptor,
+                token.GetLocation(),
                 messageArgs));
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecorateFunctions.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecorateFunctions.cs
@@ -24,7 +24,7 @@ public sealed class DecorateFunctions : DiagnosticAnalyzer
             && NotObsolete(method)
             && NotDecorated(method.GetAttributes()))
         {
-            context.ReportDiagnostic(Description.DecorateFunctions, declaration);
+            context.ReportDiagnostic(Description.DecorateFunctions, declaration.ChildTokens().First(t => t.IsKind(SyntaxKind.IdentifierToken)));
         }
     }
 


### PR DESCRIPTION
When rule `QW0003` is triggered, the whole method is marked as invalid. Just highlighting the method name  would be sufficient.