### PR TITLE
FN QW0005: Overrides on protected members do not make a class designed for inheritance

### DIFF
--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/SealClasses.Records.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/SealClasses.Records.cs
@@ -24,9 +24,14 @@ namespace Noncompliant
 
     public record NotAbstractWithVirtualBase : VirtualBase { } // Noncompliant
 
+    public record WithProtectedOverride : VirtualBase // Noncompliant
+    {
+        protected override object Property { get; set; }
+    }
+
     public abstract record VirtualBase
     {
-        public virtual object Property { get; set; }
+        protected virtual object Property { get; set; }
     }
 }
 

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/SealClasses.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/SealClasses.cs
@@ -24,9 +24,14 @@ namespace Noncompliant
 
     public class NotAbstractWithVirtualBase : VirtualBase { } // Noncompliant
 
+    public class WithProtectedOverride : VirtualBase // Noncompliant
+    {
+        protected override object Property { get; set; }
+    }
+
     public abstract class VirtualBase
     {
-        public virtual object Property { get; set; }
+        protected virtual object Property { get; set; }
     }
 }
 

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/SealClasses.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/SealClasses.cs
@@ -37,7 +37,9 @@ namespace Noncompliant
 
 namespace Compliant
 {
-    public class SomeAttribute : Attribute { } // Compliant {{Are ignored.}}
+    public class SomeAttribute : Attribute { } // Compliant {{Attributes are ignored.}}
+
+    public class SomeExceptoin : Exception { } // Compliant {{Exceptions are ignored.}}
 
     [Inheritable]
     public class WithAttribute { } // Compliant {{Decorated with Inheritable attribute.}}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
@@ -14,9 +14,17 @@ internal static class SymbolExtensions
         => symbol is { } && symbol.IsMatch(type);
 
     [Pure]
+    public static bool IsAssignableTo(this ITypeSymbol? symbol, SystemType type)
+        => symbol is { } && symbol.IsMatch(type)
+        || (symbol?.BaseType is { } @base && @base.Is(type));
+
+    [Pure]
     public static bool IsAttribute(this ITypeSymbol type)
-        => type.Is(SystemType.System_Attribute)
-        || (type.BaseType is { } @base && @base.IsAttribute());
+        => type.IsAssignableTo(SystemType.System_Attribute);
+
+    [Pure]
+    public static bool IsException(this ITypeSymbol type)
+        => type.IsAssignableTo(SystemType.System_Exception);
 
     [Pure]
     public static bool IsObsolete(this ITypeSymbol type)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/SealClasses.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/SealClasses.cs
@@ -31,6 +31,7 @@ public sealed class SealClasses : DiagnosticAnalyzer
             && declaration.Symbol is { } type
             && !type.IsObsolete()
             && !type.IsAttribute()
+            && !type.IsException()
             && !type.GetMembers().Any(IsVirtualOrProtected)
             && Decorated(type.GetAttributes()) is null)
         {
@@ -47,6 +48,7 @@ public sealed class SealClasses : DiagnosticAnalyzer
             && declaration.Symbol is { } type
             && !type.IsObsolete()
             && !type.IsAttribute()
+            && !type.IsException()
             && Decorated(type.GetAttributes()) is { } decorated
             && declaration.Attributes.FirstOrDefault(a => IsDecorated(a, decorated)) is { } attr)
         {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/SealClasses.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/SealClasses.cs
@@ -63,8 +63,11 @@ public sealed class SealClasses : DiagnosticAnalyzer
 
     [Pure]
     private static bool IsVirtualOrProtected(ISymbol symbol)
-        => (symbol.IsVirtual || symbol.IsProtected())
-        && !symbol.IsImplicitlyDeclared;
+        => !symbol.IsImplicitlyDeclared && (symbol.IsVirtual || IsProtected(symbol));
+
+    [Pure]
+    private static bool IsProtected(ISymbol symbol)
+        => symbol.IsProtected() && !symbol.IsOverride;
 
     [Pure]
     private static INamedTypeSymbol? Decorated(IEnumerable<AttributeData> attributes)

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -6,6 +6,7 @@ public partial class SystemType
     public static readonly SystemType System_Void = New(typeof(void), SpecialType.System_Void);
 
     public static readonly SystemType System_Attribute = typeof(System.Attribute);
+    public static readonly SystemType System_Exception = typeof(System.Exception);
     public static readonly SystemType System_IDisposable = typeof(System.IDisposable);
     public static readonly SystemType System_ObsoleteAttribute = typeof(System.ObsoleteAttribute);
 


### PR DESCRIPTION
Having a overridden protected member (property of function) should not count as designed for inheritance.