### PR TITLE
FP QW0005: All attributes should be excluded

### DIFF
--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/SealClasses.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/SealClasses.cs
@@ -92,5 +92,6 @@ namespace Compliant
 
 
     public class InheritableAttribute : Attribute { }
-    public sealed class SupportsMockingAttribute : InheritableAttribute { }
+
+    public class SupportsMockingAttribute : InheritableAttribute { }
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
@@ -1,6 +1,4 @@
-﻿using System.IO;
-
-namespace Microsoft.CodeAnalysis;
+﻿namespace Microsoft.CodeAnalysis;
 
 internal static class SymbolExtensions
 {
@@ -15,7 +13,7 @@ internal static class SymbolExtensions
     [Pure]
     public static bool IsAssignableTo(this ITypeSymbol? symbol, SystemType type)
         => symbol is { } && symbol.IsMatch(type)
-        || (symbol?.BaseType is { } @base && @base.Is(type));
+        || (symbol?.BaseType is { } @base && @base.IsAssignableTo(type));
 
     [Pure]
     public static bool IsAttribute(this ITypeSymbol type)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -17,9 +17,11 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package config">
-    <PackageVersion>0.0.5.1</PackageVersion>
+    <PackageVersion>0.0.5.2</PackageVersion>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>
+v0.0.5.2
+- QW0005: All attributes should be excluded. (#15)
 v0.0.5.1
 - QW0004: Mathematical Alphanumeric Symbols are not suspicious. (#14)
 v0.0.5


### PR DESCRIPTION
All attributes should be excluded, not only those who *directly* inherit from `System.Attribute`.

``` C#
public class AnyAttribute : ValidationAttribute // Compliant
{
}
```