### PR TITLE
FP: Methods returning ValueTask are impure by definition

### DIFF
--- a/rules/QW0003.md
+++ b/rules/QW0003.md
@@ -33,8 +33,6 @@ public class Compliant
 
     public void Void() { } // Void methods are impure per definition.
 
-    public IDisposable Scope() => null; // Disposable methods are expected to be impure.
-
     public bool TryParse(string str, out object result) // Methods with out parameters are expected to be impure.
     {
         if (str is null)

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DecoratePureFunctions.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DecoratePureFunctions.cs
@@ -22,9 +22,23 @@ public class Compliant
     [Obsolete]
     public int Obsolete() => 0; // Compliant {{Obsolete methods are ignored.}}
 
+    [Impure]
+    public int ImpureMethod(int input) => 42; // Compliant {{Decorated with something derived from an ImpureAttribute.}}
+
+    [FluenSyntax]
+    public Compliant FluentSyntax() => this; // Compliant {{Decorated with something derived from an ImpureAttribute.}}
+
+    [CustomAssertion]
+    public T SomeAssertion<T>(T subject) => subject; // Compliant {{FluentAssertions custom assertions are expected to be impure.}}
+}
+
+public class ImpureByAssumption
+{
     public void Void() { } // Compliant {{Void methods are impure per definition.}}
 
-    public Task AsyncVoid() => Task.CompletedTask; // Compliant
+    public Task AsyncVoid() => Task.CompletedTask; // Compliant {{Async void methods are impure per definition.}}
+
+    public async ValueTask AsyncVoidStruct() => await AsyncVoid(); // Compliant {{Async void methods are impure per definition.}}
 
     public IDisposable Scope() => null; // Compliant {{Disposable methods are expected to be impure.}}
 
@@ -43,15 +57,6 @@ public class Compliant
     }
 
     public int GuardPositive(int number) => number; // Compliant {{Guarding is expected to be impure.}}
-
-    [Impure]
-    public int ImpureMethod(int input) => 69; // Compliant {{Decorated with something derived from an ImpureAttribute.}}
-
-    [FluenSyntax]
-    public Compliant FluentSyntax() => this; // Compliant {{Decorated with something derived from an ImpureAttribute.}}
-
-    [CustomAssertion]
-    public T SomeAssertion<T>(T subject) => subject; // Compliant {{FluentAssertions custom assertions are expected to be impure.}}
 }
 
 public class Guard

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DecoratePureFunctions.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DecoratePureFunctions.cs
@@ -25,7 +25,7 @@ public class Compliant
     [Impure]
     public int ImpureMethod(int input) => 42; // Compliant {{Decorated with something derived from an ImpureAttribute.}}
 
-    [FluenSyntax]
+    [FluentSyntax]
     public Compliant FluentSyntax() => this; // Compliant {{Decorated with something derived from an ImpureAttribute.}}
 
     [CustomAssertion]
@@ -39,8 +39,6 @@ public class ImpureByAssumption
     public Task AsyncVoid() => Task.CompletedTask; // Compliant {{Async void methods are impure per definition.}}
 
     public async ValueTask AsyncVoidStruct() => await AsyncVoid(); // Compliant {{Async void methods are impure per definition.}}
-
-    public IDisposable Scope() => null; // Compliant {{Disposable methods are expected to be impure.}}
 
     public bool TryParse(string str, out object result) // Compliant {{Methods with out parameters are expected to be impure.}}
     {
@@ -72,4 +70,4 @@ public class ObsoleteClass
 
 public class OtherAttribute : Attribute { }
 public class ImpureAttribute : Attribute { }
-public class FluenSyntaxAttribute : ImpureAttribute { }
+public class FluentSyntaxAttribute : ImpureAttribute { }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -22,7 +22,8 @@
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>
 v0.0.5.3
-- QW0003: ValueTask is never a pure function. (#16)
+- QW0003: Returning ValueTask is never a pure function. (#16)
+- QW0003: Returning IDisposable can be a pure function. (#16)
 v0.0.5.2
 - QW0005: All attributes should be excluded. (#15)
 v0.0.5.1

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -18,9 +18,11 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package config">
-    <PackageVersion>0.0.5.2</PackageVersion>
+    <PackageVersion>0.0.5.3</PackageVersion>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>
+v0.0.5.3
+- QW0003: ValueTask is never a pure function. (#16)
 v0.0.5.2
 - QW0005: All attributes should be excluded. (#15)
 v0.0.5.1

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
@@ -31,6 +31,7 @@ public sealed class DecoratePureFunctions : DiagnosticAnalyzer
     private bool ReturnsResult(ITypeSymbol type)
         => type.IsNot(SystemType.System_Void)
         && type.IsNot(SystemType.System_Threading_Task)
+        && type.IsNot(SystemType.System_Threading_ValueTask)
         && type.IsNot(SystemType.System_IDisposable);
 
     private static bool HasNoRefOutParemeter(IEnumerable<IParameterSymbol> parameters)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
@@ -31,8 +31,7 @@ public sealed class DecoratePureFunctions : DiagnosticAnalyzer
     private bool ReturnsResult(ITypeSymbol type)
         => type.IsNot(SystemType.System_Void)
         && type.IsNot(SystemType.System_Threading_Task)
-        && type.IsNot(SystemType.System_Threading_ValueTask)
-        && type.IsNot(SystemType.System_IDisposable);
+        && type.IsNot(SystemType.System_Threading_ValueTask);
 
     private static bool HasNoRefOutParemeter(IEnumerable<IParameterSymbol> parameters)
         => parameters.All(par => par.RefKind != RefKind.Out && par.RefKind != RefKind.Ref);

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -12,4 +12,5 @@ public partial class SystemType
 
     public static readonly SystemType System_Diagnostics_Contracts_PureAttribute = typeof(System.Diagnostics.Contracts.PureAttribute);
     public static readonly SystemType System_Threading_Task = typeof(System.Threading.Tasks.Task);
+    public static readonly SystemType System_Threading_ValueTask = typeof(System.Threading.Tasks.ValueTask);
 }


### PR DESCRIPTION
Rule QW0003 states that methods should be decorated with the `[Pure]` attribute, except when they can not be pure at. So `void`, and `Task` are excluded. However, `ValueTask` was missing.