### PR TITLE
Fix for time provider

### DIFF
--- a/rules/QW0001.md
+++ b/rules/QW0001.md
@@ -1,7 +1,11 @@
 # QW0001: Use a testable Time Provider
 For testability, the behavior of time providers should
 be adjustable under test. `DateTime.Now`, `DateTime.UtcNow`,
-`DateTime.Today` lack this possibility.
+`DateTime.Today`, `DateTimeOffset.Now`, and `DateTimeOffset.UtcNow`
+lack this possibility.
+
+Note that Sonar has rule [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354).
+If you prefer, you could use that rule instead.
 
 ## Non-compliant
 ``` C#

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.Fixed.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.Fixed.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+public class DateTimeAsProvider
+{
+    public void Issues()
+    {
+        var now = Clock.Now();
+        var utc = Clock.UtcNow();
+        var today = Clock.Today()
+        var offset_now = Clock.NowWithOffset();
+        var offset_utc = Clock.NowWithOffset(TimeZoneInfo.Utc);
+    }
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.Fixed.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.Fixed.cs
@@ -6,7 +6,7 @@ public class DateTimeAsProvider
     {
         var now = Clock.Now();
         var utc = Clock.UtcNow();
-        var today = Clock.Today()
+        var today = Clock.Today();
         var offset_now = Clock.NowWithOffset();
         var offset_utc = Clock.NowWithOffset(TimeZoneInfo.Utc);
     }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.ToFix.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.ToFix.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+public class DateTimeAsProvider
+{
+    public void Noncompliant()
+    {
+        var now = DateTime.Now;
+        var utc = DateTime.UtcNow;
+        var today = DateTime.Today;
+        var offset_now = DateTimeOffset.Now;
+        var offset_utc = DateTimeOffset.UtcNow;
+    }
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.ToFix.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.ToFix.cs
@@ -2,7 +2,7 @@
 
 public class DateTimeAsProvider
 {
-    public void Noncompliant()
+    public void Issues()
     {
         var now = DateTime.Now;
         var utc = DateTime.UtcNow;

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseTestableTimeProvider.cs
@@ -8,6 +8,8 @@ public class DateTimeAsProvider
         //        ^^^^^^^^^^^^
         var utc = DateTime.UtcNow; // Noncompliant
         var today = DateTime.Today; // Noncompliant
+        var offset_now = DateTimeOffset.Now; // Noncompliant
+        var offset_utc = DateTimeOffset.UtcNow; // Noncompliant
     }
 
     public void CompliantAre()

--- a/specs/Qowaiv.CodeAnalysis.Specs/Properties/GlobalUsings.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Properties/GlobalUsings.cs
@@ -2,6 +2,6 @@
 global using FluentAssertions;
 global using NUnit.Framework;
 global using Qowaiv.CodeAnalysis;
-global using Qowaiv.CodeAnalysis.Diagnostics;
+global using Qowaiv.CodeAnalysis.CodeFixes;
 global using Qowaiv.CodeAnalysis.Rules;
 global using System.Linq;

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_testable_time_provider.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_testable_time_provider.cs
@@ -1,3 +1,7 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
 namespace Rules.Use_testable_time_provider;
 
 public class Verify
@@ -10,14 +14,20 @@ public class Verify
         .Verify();
 }
 
-public class Fix
+public class Fixes
 {
     [Test]
-    public void QW0001()
+    public void Code()
         => new UseTestableTimeProvider()
         .ForCS()
         .AddSource(@"Cases/UseTestableTimeProvider.ToFix.cs")
         .ForCodeFix<UseQowaivClock>()
         .AddSource(@"Cases/UseTestableTimeProvider.Fixed.cs")
         .Verify();
+
+    [Test]
+    public void Both_S6354_and_QW0001()
+        => new UseQowaivClock()
+        .FixableDiagnosticIds
+        .Should().BeEquivalentTo("S6354", "QW0001");
 }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_testable_time_provider.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_testable_time_provider.cs
@@ -9,3 +9,15 @@ public class Verify
         .AddSource(@"Cases/UseTestableTimeProvider.cs")
         .Verify();
 }
+
+public class Fix
+{
+    [Test]
+    public void QW0001()
+        => new UseTestableTimeProvider()
+        .ForCS()
+        .AddSource(@"Cases/UseTestableTimeProvider.ToFix.cs")
+        .ForCodeFix<UseQowaivClock>()
+        .AddSource(@"Cases/UseTestableTimeProvider.Fixed.cs")
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/UseQowaivClock.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/UseQowaivClock.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using System.Threading;
+using System.Threading.Tasks;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Qowaiv.CodeAnalysis.CodeFixes;
+
+public sealed class UseQowaivClock : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => new[]
+    {
+        Rule.UseTestableTimeProvider.Id,
+        "S6354"
+    }
+    .ToImmutableArray();
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        if (await context.DiagnosticContext() is { } diagnostic
+            && diagnostic.Token.Parent!.AncestorsAndSelf<MemberAccessExpressionSyntax>() is { } member)
+        {
+            diagnostic.RegisterCodeFix("Use Qowaiv.Clock.", context, (d, c) => ChangeDocument(d, member, c));
+        }
+    }
+
+    private async Task<Document> ChangeDocument(DiagnosticContext context, MemberAccessExpressionSyntax oldNode, CancellationToken cancellation)
+    {
+        var model = await context.GetSemanticModelAsync(cancellation);
+        var property = (IPropertySymbol)model.GetSymbolInfo(oldNode).Symbol!;
+
+        var clock = IdentifierName("Clock");
+        var method = Method(property);
+
+        var newNode = InvocationExpression(
+            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, clock, method),
+            Arguments(property));
+
+        return context.Document.WithSyntaxRoot(context.Root.ReplaceNode(oldNode, newNode));
+    }
+
+    private static IdentifierNameSyntax Method(IPropertySymbol property) 
+        => property.MemberOf(SystemType.System_DateTimeOffset)
+        ? IdentifierName("NowWithOffset") 
+        : IdentifierName(property.Name);
+
+    private static ArgumentListSyntax Arguments(IPropertySymbol property)
+        => property.MemberOf(SystemType.System_DateTimeOffset) && property.Name == "UtcNow"
+        ? ArgumentList(SeparatedList(new SyntaxNode[] { TimeZoneInfo_Utc() }))
+        : ArgumentList(default);
+
+    private static MemberAccessExpressionSyntax TimeZoneInfo_Utc() => MemberAccessExpression(
+        SyntaxKind.SimpleMemberAccessExpression,
+        IdentifierName(nameof(TimeZoneInfo)),
+        IdentifierName(nameof(TimeZoneInfo.Utc)));
+
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.CodeFixes.CodeFixContext.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.CodeFixes.CodeFixContext.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.CodeAnalysis.CodeActions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.CodeFixes;
+
+/// <summary>Extensions on <see cref="CodeFixContext"/>.</summary>
+internal static  class CodeFixContextExtensions
+{
+    public static async Task<DiagnosticContext?> DiagnosticContext(this CodeFixContext context)
+    {
+        if(context.Diagnostics.FirstOrDefault() is { } diagnostic)
+        {
+            var root =await context.Document.GetSyntaxRootAsync(context.CancellationToken);
+            return new(context.Document, diagnostic, root!);
+        }
+        else
+        {
+            return null;
+        }
+    }
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.SyntaxNode.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.SyntaxNode.cs
@@ -1,7 +1,10 @@
 ﻿namespace Microsoft.CodeAnalysis;
 
-public static class SyntaxNodeExensions
+public static class SyntaxNodeExtensions
 {
+    public static TNode? AncestorsAndSelf<TNode>(this SyntaxNode node) where TNode : SyntaxNode
+        => node.AncestorsAndSelf().OfType<TNode>().FirstOrDefault();
+
     public static string? Name(this SyntaxNode node) => node switch
     {
         AttributeSyntax attr => Name(attr.Name),

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -18,9 +18,11 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package config">
-    <PackageVersion>0.0.5.3</PackageVersion>
+    <PackageVersion>0.0.6</PackageVersion>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>
+v0.0.6
+- QW0001: Also reports on DateTime.Offset. (#17)
 v0.0.5.3
 - QW0003: Returning ValueTask is never a pure function. (#16)
 - QW0003: Returning IDisposable can be a pure function. (#16)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseTestableTimeProvider.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseTestableTimeProvider.cs
@@ -16,14 +16,14 @@ public sealed class UseTestableTimeProvider : DiagnosticAnalyzer
     {
         if (IsDateTimeProvider(context.Node.Name())
             && context.SemanticModel.GetSymbolInfo(context.Node).Symbol is IPropertySymbol property
-            && property.MemberOf(SystemType.System_DateTime))
+            && (property.MemberOf(SystemType.System_DateTime) || property.MemberOf(SystemType.System_DateTimeOffset)))
         {
             context.ReportDiagnostic(Rule.UseTestableTimeProvider, context.Node.Parent!);
         }
     }
 
     private bool IsDateTimeProvider(string? name)
-       => nameof(DateTime.Now).Equals(name)
-       || nameof(DateTime.UtcNow).Equals(name)
-       || nameof(DateTime.Today).Equals(name);
+        => nameof(DateTime.Now).Equals(name)
+        || nameof(DateTime.UtcNow).Equals(name)
+        || nameof(DateTime.Today).Equals(name);
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/DiagnosticContext.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/DiagnosticContext.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Qowaiv.CodeAnalysis.Syntax;
+
+internal sealed class DiagnosticContext
+{
+    public DiagnosticContext(Document document, Diagnostic diagnostic, SyntaxNode root)
+    {
+        Document = document;
+        Diagnostic = diagnostic;
+        Root = root;
+    }
+
+    public Document Document { get; }
+
+    public Diagnostic Diagnostic { get; }
+    
+    public SyntaxNode Root { get; }
+
+    public async Task<SemanticModel> GetSemanticModelAsync(CancellationToken cancellation = default)
+    {
+        SemanticModel ??= await Document.GetSemanticModelAsync(cancellation);
+        return SemanticModel!;
+    }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private SemanticModel? SemanticModel;
+
+    public SyntaxToken Token => Root.FindToken(Diagnostic.Location.SourceSpan.Start);
+
+    public void RegisterCodeFix(
+            string title,
+            CodeFixContext context,
+            Func<DiagnosticContext, CancellationToken, Task<Document>> createChangedDocument)
+
+      => context.RegisterCodeFix(CodeAction.Create(title, c => createChangedDocument(this, c)), Diagnostic);
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -6,6 +6,7 @@ public partial class SystemType
     public static readonly SystemType System_Void = New(typeof(void), SpecialType.System_Void);
 
     public static readonly SystemType System_Attribute = typeof(System.Attribute);
+    public static readonly SystemType System_DateTimeOffset = typeof(System.DateTimeOffset);
     public static readonly SystemType System_Exception = typeof(System.Exception);
     public static readonly SystemType System_IDisposable = typeof(System.IDisposable);
     public static readonly SystemType System_ObsoleteAttribute = typeof(System.ObsoleteAttribute);


### PR DESCRIPTION
When [QW0001](https://github.com/Qowaiv/qowaiv-analyzers/blob/main/rules/QW0001.md) or its equivalent ([S6354](https://rules.sonarsource.com/csharp/RSPEC-6354)) reports an issue, a fix is proposed to use `Qowaiv.UtcNow()` (or any of its alternatives instead.

As suggested #18