### PR TITLE
New Rule: Use System.DateOnly instead of Qowaiv.Date

### DIFF
--- a/Qowaiv.Analyzers.sln
+++ b/Qowaiv.Analyzers.sln
@@ -35,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "rules", "rules", "{00461C52
 		rules\QW0007.md = rules\QW0007.md
 		rules\QW0008.md = rules\QW0008.md
 		rules\QW0009.md = rules\QW0009.md
+		rules\QW0010.md = rules\QW0010.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{EE67C148-3FE3-4DF4-8A91-C0BF7E3960AD}"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * [**QW0007** - Use file-scoped namespace declarations](rules/QW0007.md)
 * [**QW0008** - Define properties as not-nullable for types with a defined empty state](rules/QW0008.md)
 * [**QW0009** - Define properties as not-nullable for enums with a defined none/empty value](rules/QW0009.md)
+* [**QW0010** - Use System.DateOnly instead of Qowaiv.Date](rules/QW0010.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))

--- a/README.md
+++ b/README.md
@@ -26,4 +26,6 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))
 * Seal class ([QW0005](rules/QW0005.md))
 * Change property type to not-nullable ([QW0008](rules/QW0008.md), [QW0009](rules/QW0009.md))
+* Change type System.DateOnly ([QW0010](rules/QW0010.md))
 * Apply suggestions of obsolete code attribute ([CS0618, CS0619])/rules/ObsoleteCode.md))
+

--- a/rules/QW0010.md
+++ b/rules/QW0010.md
@@ -7,20 +7,20 @@ not longer of added value when .NET 6.0 or higher is used.
 
 ## Non-compliant
 ``` C#
-SomeClass
+class SomeClass
 {
     public Date Value { get; }
 }
 
-SomeRecord(Date Value);
+record SomeRecord(Date Value);
 ```
 
 ## Compliant
 ``` C#
-SomeClass
+class SomeClass
 {
     public DateOnly Value { get; }
 }
 
-SomeRecord(DateOnly Value);
+record SomeRecord(DateOnly Value);
 ```

--- a/rules/QW0010.md
+++ b/rules/QW0010.md
@@ -1,0 +1,26 @@
+# QW0010: Use System.DateOnly instead of Qowaiv.Date
+
+The purpose of `Qowaiv.Date` is to provide a date (only) alternative to
+`System.DateTime`. Since .NET 6.0, however Microsoft (finally) provides a date
+only implementation: `System.DateOnly`. Therefor, the usage of `Qowaiv.Date` is
+not longer of added value when .NET 6.0 or higher is used.
+
+## Non-compliant
+``` C#
+SomeClass
+{
+    public Date Value { get; }
+}
+
+SomeRecord(Date Value);
+```
+
+## Compliant
+``` C#
+SomeClass
+{
+    public DateOnly Value { get; }
+}
+
+SomeRecord(DateOnly Value);
+```

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ChangeQowaivDateToSystemDateOnly.Fixed.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ChangeQowaivDateToSystemDateOnly.Fixed.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Qowaiv;
+using System.Collections.Generic;
+
+public class SomeModel
+{
+    private readonly DateOnly Field;
+
+    public DateOnly Property { get; set; }
+
+    public DateOnly[] Array { get; set; }
+
+    public List<DateOnly> List { get; set; }
+
+    public DateOnly? NullableProperty { get; set; }
+
+    public DateOnly SomeMethod() => default;
+
+    public DateOnly? SomeNullableMethod() => default;
+}
+
+public record SomeRecord(DateOnly Property);

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ChangeQowaivDateToSystemDateOnly.Fixed.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ChangeQowaivDateToSystemDateOnly.Fixed.cs
@@ -17,6 +17,8 @@ public class SomeModel
     public DateOnly SomeMethod() => default;
 
     public DateOnly? SomeNullableMethod() => default;
+
+    public void Arguments(DateOnly argument) { }
 }
 
 public record SomeRecord(DateOnly Property);

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ChangeQowaivDateToSystemDateOnly.ToFix.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ChangeQowaivDateToSystemDateOnly.ToFix.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Qowaiv;
+using System.Collections.Generic;
+
+public class SomeModel
+{
+    private readonly Qowaiv.Date Field;
+
+    public Qowaiv.Date Property { get; set; }
+
+    public Qowaiv.Date[] Array { get; set; }
+
+    public List<Qowaiv.Date> List { get; set; }
+
+    public Date? NullableProperty { get; set; }
+
+    public Date SomeMethod() => default;
+
+    public Qowaiv.Date? SomeNullableMethod() => default;
+}
+
+public record SomeRecord(Qowaiv.Date Property);

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ChangeQowaivDateToSystemDateOnly.ToFix.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ChangeQowaivDateToSystemDateOnly.ToFix.cs
@@ -17,6 +17,8 @@ public class SomeModel
     public Date SomeMethod() => default;
 
     public Qowaiv.Date? SomeNullableMethod() => default;
+
+    public void Arguments(Qowaiv.Date argument) { }
 }
 
 public record SomeRecord(Qowaiv.Date Property);

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseSystemDateOnly.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseSystemDateOnly.cs
@@ -11,6 +11,9 @@ namespace Noncompliant
         public Qowaiv.Date? NullableProperty { get; set; } // Noncompliant
         //     ^^^^^^^^^^^^
 
+        public Qowaiv.Date[] Properties { get; set; } // Noncompliant
+        //     ^^^^^^^^^^^
+
         public Qowaiv.Date SomeMethod() => default; // Noncompliant
         //     ^^^^^^^^^^^
 

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseSystemDateOnly.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseSystemDateOnly.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Compliant;
+using System;
 
 namespace Noncompliant
 {
@@ -18,6 +19,9 @@ namespace Noncompliant
         //     ^^^^^^^^^^^
 
         public Qowaiv.Date? SomeNullableMethod() => default; // Noncompliant
+
+        public void Arguments(Qowaiv.Date argument) { } // Noncompliant
+        //                    ^^^^^^^^^^^
     }
 
     public record SomeRecord(Qowaiv.Date Property); // Noncompliant

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseSystemDateOnly.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseSystemDateOnly.cs
@@ -1,0 +1,48 @@
+﻿using System;
+
+namespace Noncompliant
+{
+    public class SomeModel
+    {
+        private readonly Qowaiv.Date Field; // Noncompliant {{Use DateOnly instead of Date.}}
+        //               ^^^^^^^^^^^
+        public Qowaiv.Date Property { get; set; } // Noncompliant
+
+        public Qowaiv.Date? NullableProperty { get; set; } // Noncompliant
+        //     ^^^^^^^^^^^^
+
+        public Qowaiv.Date SomeMethod() => default; // Noncompliant
+        //     ^^^^^^^^^^^
+
+        public Qowaiv.Date? SomeNullableMethod() => default; // Noncompliant
+    }
+
+    public record SomeRecord(Qowaiv.Date Property); // Noncompliant
+    //                       ^^^^^^^^^^^
+}
+
+namespace Compliant
+{
+    public class SomeModel
+    {
+        private readonly DateOnly Field; // Compliant
+
+        public DateOnly Property { get; set; } // Compliant
+
+        public DateOnly? NullableProperty { get; set; } // Compliant
+
+        public DateOnly SomeMethod() => default; // Compliant
+
+        public DateOnly? SomeNullableMethod() => default; // Compliant
+
+        public Date OtherDate() => default; // Compliant {{Type is not involved.}}
+
+        public int OtherType() => 42; // Compliant {{Type is not involved.}}
+
+        public DateOnly Today() => Qowaiv.Clock.Today(); // Complaint {{The usage of Qowaiv.Date is fine.}}
+    }
+
+    public record SomeRecord(DateOnly Property); // Compliant
+
+    public struct Date { }
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Fixes/Change_Qowaiv_Date_to_System_DateOnly.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Fixes/Change_Qowaiv_Date_to_System_DateOnly.cs
@@ -1,0 +1,13 @@
+﻿namespace Fixes.Change_Qowaiv_Date_to_System_DateOnly;
+
+public class Fixes
+{
+    [Test]
+    public void Code() => new UseSystemDateOnly()
+        .ForCS()
+        .AddReference<Qowaiv.Date>()
+        .AddSource(@"Cases/ChangeQowaivDateToSystemDateOnly.ToFix.cs")
+        .ForCodeFix<ChangeQowaivDateToSystemDateOnly>()
+        .AddSource(@"Cases/ChangeQowaivDateToSystemDateOnly.Fixed.cs")
+        .Verify();
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_System_DateOnly.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_System_DateOnly.cs
@@ -1,0 +1,11 @@
+﻿namespace Rules.Use_System_DateOnly;
+
+public class Verify
+{
+    [Test]
+    public void Rule() => new UseSystemDateOnly()
+        .ForCS()
+        .AddSource(@"Cases/UseSystemDateOnly.cs")
+        .AddReference<Qowaiv.Date>()
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/ChangeQowaivDateToSystemDateOnly.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/ChangeQowaivDateToSystemDateOnly.cs
@@ -1,0 +1,34 @@
+﻿using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Qowaiv.CodeAnalysis.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public sealed class ChangeQowaivDateToSystemDateOnly : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => new[]
+    {
+        Rule.UseSystemDateOnly.Id,
+    }
+    .ToImmutableArray();
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        if (await context.ChangeDocumentContext() is { Node: { } } change)
+        {
+            change.RegisterCodeFix("Change type to System.DateOnly.", context, ChangeDocument);
+        }
+    }
+
+    private static Task<Document> ChangeDocument(ChangeDocumentContext context) 
+        => context.ReplaceNode(
+            Identifier(context.Node) ?? context.Node!,
+            IdentifierName("DateOnly"));
+
+    private static SyntaxNode? Identifier(SyntaxNode? node) => node switch
+    {
+        null => null,
+        IdentifierNameSyntax name => name,
+        NullableTypeSyntax nullable => nullable.ElementType,
+        _ => Identifier(node.Parent),
+    };
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/ChangeQowaivDateToSystemDateOnly.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/ChangeQowaivDateToSystemDateOnly.cs
@@ -3,19 +3,13 @@
 namespace Qowaiv.CodeAnalysis.CodeFixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp)]
-public sealed class ChangeQowaivDateToSystemDateOnly : CodeFixProvider
+public sealed class ChangeQowaivDateToSystemDateOnly() : CodeFix(Rule.UseSystemDateOnly.Id)
 {
-    public override ImmutableArray<string> FixableDiagnosticIds => new[]
-    {
-        Rule.UseSystemDateOnly.Id,
-    }
-    .ToImmutableArray();
-
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         if (await context.ChangeDocumentContext() is { Node: { } } change)
         {
-            change.RegisterCodeFix("Change type to System.DateOnly.", context, ChangeDocument);
+            change.RegisterFix("Change type to System.DateOnly.", context, ChangeDocument);
         }
     }
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -22,6 +22,7 @@
     <PackageReleaseNotes>
 v1.0.0
 - QW0010: Use System.DateOnly instead of Qowaiv.Date. #29
+- CS0618, CS0619: Code fix for obsolete code with a suggestion. #30
 - Depend on Microsoft.CodeAnalysis 4.*. #27
 v0.0.8
 - Code fix for QW0005: Seal class. #26

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -21,8 +21,8 @@
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>
 v1.0.0
-- QW0010: Use System.DateOnly instead of Qowaiv.Date.
-- Depend on Microsoft.CodeAnalysis 4.*.
+- QW0010: Use System.DateOnly instead of Qowaiv.Date. #29
+- Depend on Microsoft.CodeAnalysis 4.*. #27
 v0.0.8
 - Code fix for QW0005: Seal class. #26
 - FN: Generics containing types that should not be nullable are now taken into account. #25
@@ -43,20 +43,20 @@ v0.0.5.2
 v0.0.5.1
 - QW0004: Mathematical Alphanumeric Symbols are not suspicious. #14
 v0.0.5
-- QW0007: Use file-scoped namespace scopes #13
+- QW0007: Use file-scoped namespace scopes. #13
 v0.0.4.1
-- QW0006: Seal concrete classes unless designed for inheritance #9
+- QW0006: Seal concrete classes unless designed for inheritance. #9
 v0.0.4
-- QW0005: Seal concrete classes unless designed for inheritance #9
+- QW0005: Seal concrete classes unless designed for inheritance. #9
 v0.0.3.1
-- QW0004: Horizontal tab (U+9, \t) is allowed too #6
+- QW0004: Horizontal tab (U+9, \t) is allowed too. #6
 v0.0.3
-- QW0004: Characters with Trojan Horse potential are not allowed
+- QW0004: Characters with Trojan Horse potential are not allowed.
 v0.0.2
-- QW0003: Decorate pure functions
+- QW0003: Decorate pure functions.
 v0.0.1
-- QW0001: Use a testable time provider
-- QW0002: Parse() throws
+- QW0001: Use a testable time provider.
+- QW0002: Parse() throws.
     </PackageReleaseNotes>
     <PackageProjectUrl>http://www.github.com/Qowaiv/qowaiv-analyzers</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -21,7 +21,8 @@
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>
 v1.0.0
- - Depend on Microsoft.CodeAnalysis 4.*.
+- QW0010: Use System.DateOnly instead of Qowaiv.Date.
+- Depend on Microsoft.CodeAnalysis 4.*.
 v0.0.8
 - Code fix for QW0005: Seal class. #26
 - FN: Generics containing types that should not be nullable are now taken into account. #25

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable SA1118 // Parameter should not span multiple lines.
+#pragma warning disable SA1118 // Parameter should not span multiple lines.
 // For readability, here it is preferred.
 
 namespace Qowaiv.CodeAnalysis;
@@ -99,6 +99,16 @@ public static partial class Rule
             "none/empty state.",
         category: Category.Design,
         tags: ["Design", "Enum", "Enumeration"]);
+
+    public static DiagnosticDescriptor UseSystemDateOnly => New(
+       id: 0010,
+       title: "Use System.DateOnly instead of Qowaiv.Date",
+       message: "Use DateOnly instead of Date.",
+       description:
+            "The purpose of `Qowaiv.Date` is to provide a date (only) alternative to DateTime. " +
+            "Since .NET 6.0, Microsoft provides DateOnly.",
+       category: Category.Design,
+       tags: ["Design", "SVO"]);
 
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemDateOnly.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemDateOnly.cs
@@ -9,8 +9,8 @@ public sealed class UseSystemDateOnly : CodingRule
     {
         context.RegisterSyntaxNodeAction(ReportField, SyntaxKind.FieldDeclaration);
         context.RegisterSyntaxNodeAction(ReportMethod, SyntaxKind.MethodDeclaration);
+        context.RegisterSyntaxNodeAction(ReportParameterList, SyntaxKind.ParameterList);
         context.RegisterSyntaxNodeAction(ReportProperty, SyntaxKind.PropertyDeclaration);
-        context.RegisterSyntaxNodeAction(ReportRecord, SyntaxKind.RecordDeclaration);
     }
 
     private void ReportField(SyntaxNodeAnalysisContext context)
@@ -19,19 +19,16 @@ public sealed class UseSystemDateOnly : CodingRule
     private void ReportMethod(SyntaxNodeAnalysisContext context)
         => Report(context.Node.Cast<MethodDeclarationSyntax>().ReturnType, context);
 
-    private void ReportProperty(SyntaxNodeAnalysisContext context)
-        => Report(context.Node.Cast<PropertyDeclarationSyntax>().Type, context);
-
-    private void ReportRecord(SyntaxNodeAnalysisContext context)
+    private void ReportParameterList(SyntaxNodeAnalysisContext context)
     {
-        if (context.Node.Cast<RecordDeclarationSyntax>().ParameterList is { } pars)
+        foreach (var type in context.Node.Cast<ParameterListSyntax>().Parameters.Select(p => p.Type))
         {
-            foreach (var type in pars.Parameters.Select(p => p.Type))
-            {
-                Report(type, context);
-            }
+            Report(type, context);
         }
     }
+
+    private void ReportProperty(SyntaxNodeAnalysisContext context)
+        => Report(context.Node.Cast<PropertyDeclarationSyntax>().Type, context);
 
     private static void Report(TypeSyntax? syntax, SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemDateOnly.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemDateOnly.cs
@@ -1,0 +1,47 @@
+﻿namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseSystemDateOnly : CodingRule
+{
+    public UseSystemDateOnly() : base(Rule.UseSystemDateOnly) { }
+
+    protected override void Register(AnalysisContext context)
+    {
+        context.RegisterSyntaxNodeAction(ReportField, SyntaxKind.FieldDeclaration);
+        context.RegisterSyntaxNodeAction(ReportMethod, SyntaxKind.MethodDeclaration);
+        context.RegisterSyntaxNodeAction(ReportProperty, SyntaxKind.PropertyDeclaration);
+        context.RegisterSyntaxNodeAction(ReportRecord, SyntaxKind.RecordDeclaration);
+    }
+
+    private void ReportField(SyntaxNodeAnalysisContext context)
+        => Report(context.Node.Cast<FieldDeclarationSyntax>().Declaration?.Type, context);
+
+    private void ReportMethod(SyntaxNodeAnalysisContext context)
+        => Report(context.Node.Cast<MethodDeclarationSyntax>().ReturnType, context);
+
+    private void ReportProperty(SyntaxNodeAnalysisContext context)
+        => Report(context.Node.Cast<PropertyDeclarationSyntax>().Type, context);
+
+    private void ReportRecord(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node.Cast<RecordDeclarationSyntax>().ParameterList is { } pars)
+        {
+            foreach (var type in pars.Parameters.Select(p => p.Type))
+            {
+                Report(type, context);
+            }
+        }
+    }
+
+    private static void Report(TypeSyntax? syntax, SyntaxNodeAnalysisContext context)
+    {
+        foreach (var sub in syntax.SubTypes())
+        {
+            if (context.SemanticModel.GetTypeInfo(sub).Type is INamedTypeSymbol type
+                && (type.NotNullable() ?? type).Is(SystemType.Qowaiv_Date))
+            {
+                context.ReportDiagnostic(Rule.UseSystemDateOnly, sub);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The purpose of `Qowaiv.Date` is to provide a date (only) alternative to `System.DateTime`. Since .NET 6.0, however Microsoft (finally) provides a date only implementation: `System.DateOnly`. Therefor, the usage of `Qowaiv.Date` is not longer of added value when .NET 6.0 or higher is used.

## Non-compliant
``` C#
class SomeClass
{
    public Date Value { get; }
}

record SomeRecord(Date Value);
```

## Compliant
``` C#
class SomeClass
{
    public DateOnly Value { get; }
}

record SomeRecord(DateOnly Value);
```
