### PR TITLE
FP QW0003: [DoesNotReturn] should be valid alternative for [Pure]

### DIFF
--- a/rules/QW0003.md
+++ b/rules/QW0003.md
@@ -52,6 +52,9 @@ public class Compliant
     [Impure]
     public int ImpureMethod(int input) => 69; // Decorated with (something derived from) an ImpureAttribute.
 
+    [DoesNotReturn]
+    public int Throws() => throw new NotSupportedException(); // Decorated to indicate that will be no answer.
+
     [CustomAssertion]
     public T SomeAssertion<T>(T subject) => subject; // Decorated with something indicating an assertion is done.
 }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DecoratePureFunctions.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DecoratePureFunctions.cs
@@ -30,6 +30,9 @@ public class Compliant
 
     [CustomAssertion]
     public T SomeAssertion<T>(T subject) => subject; // Compliant {{FluentAssertions custom assertions are expected to be impure.}}
+
+    [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute()]
+    public int WhenItNeverReturns() => throw new NotSupportedException(); // Compliant {{DoesNotReturn also indicates cleary what to expect.}}
 }
 
 public class ImpureByAssumption

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Decorate_pure_functions.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Decorate_pure_functions.cs
@@ -8,5 +8,6 @@ public class Verify
         .ForCS()
         .AddSource(@"Cases/DecoratePureFunctions.cs")
         .AddReference<FluentAssertions.CustomAssertionAttribute>()
+        .AddReference<System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute>()
         .Verify();
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -20,6 +20,8 @@
     <PackageVersion>1.0.2</PackageVersion>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>
+ToBeReleased:
+- QW0003: [DoesNotReturn] should be valid alternative for [Pure]. #33
 v1.0.2
 - QW0012: Reduce FP's by ignoring potential mutable property types. #32
 v1.0.1

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
@@ -38,7 +38,9 @@ public sealed class DecoratePureFunctions() : CodingRule(Rule.DecoratePureFuncti
         => !attributes.Any(attr => Decorated(attr.AttributeClass));
 
     private static bool Decorated(ITypeSymbol? attr)
-        => attr.Is(SystemType.System_Diagnostics_Contracts_PureAttribute)
+        => attr.IsAny(
+            SystemType.System_Diagnostics_Contracts_PureAttribute,
+            SystemType.System_Diagnostics_CodeAnalysis_DoesNotReturnAttribute)
         || DecoratedImpure(attr!);
 
     private static bool DecoratedImpure(ITypeSymbol attr)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/TypeDeclaration.Interface.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/TypeDeclaration.Interface.cs
@@ -10,5 +10,4 @@ public partial class TypeDeclaration
 
         public override IEnumerable<SyntaxKind> Modifiers => TypedNode.Modifiers.Select(m => m.Kind());
     }
-
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -24,7 +24,9 @@ public partial class SystemType
     public static readonly SystemType System_IDisposable = typeof(System.IDisposable);
     public static readonly SystemType System_ObsoleteAttribute = typeof(System.ObsoleteAttribute);
 
+    public static readonly SystemType System_Diagnostics_CodeAnalysis_DoesNotReturnAttribute = new("System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute");
     public static readonly SystemType System_Diagnostics_Contracts_PureAttribute = typeof(System.Diagnostics.Contracts.PureAttribute);
+
     public static readonly SystemType System_Threading_Task = typeof(System.Threading.Tasks.Task);
     public static readonly SystemType System_Threading_ValueTask = typeof(System.Threading.Tasks.ValueTask);
 


### PR DESCRIPTION
The `[DoesNotReturn]` indicates that the method will never return. That also tells the compiler that the response can be ignored, hence `[Pure]` or `[Impure]` is not needed.