### PR TITLE
FP QW0012: Types that have Immutable in there name are considered immutable

### DIFF
--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseImmutableTypesForProperties.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseImmutableTypesForProperties.cs
@@ -33,8 +33,11 @@ namespace Compliant
         
         public IReadOnlySet<int> Set { get; } // Compliant
 
-        public ImmutableList ImmutableList { get; } // Compliant
-        
+        public ReadOnlyList ReadOnlyList { get; } // Compliant
+
+        public System.Collections.Immutable.ImmutableArray<int> ImmutableCollection { get; } // Compliant
+
+
         public RecursiveImmutableClass Recursive { get; } // Compliant
 
         public Guid ReadOnly { get; } // Compliant {{Guids are read-only.}}
@@ -149,7 +152,7 @@ public class MutableClass { }
 
 public sealed class MutableList : List<int> { }
 
-public sealed class ImmutableList : IReadOnlyList<int>
+public sealed class ReadOnlyList : IReadOnlyList<int>
 {
     public int this[int index] => 42;
 

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_immutable_types_for_properties.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_immutable_types_for_properties.cs
@@ -7,5 +7,6 @@ public class Verify
          => new UseImmutableTypesForProperties()
         .ForCS()
         .AddSource(@"Cases/UseImmutableTypesForProperties.cs")
+        .AddReference<System.Collections.Immutable.ImmutableArray<int>>()
         .Verify();
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -20,6 +20,8 @@
     <PackageVersion>1.0.2</PackageVersion>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>
+ToBeReleased:
+- QW0012: Types that have Immutable in there name are considered immutable. #34
 v1.0.2
 - QW0012: Reduce FP's by ignoring potential mutable property types. #32
 v1.0.1

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
@@ -22,7 +22,9 @@ public sealed class UseImmutableTypesForProperties() : CodingRule(Rule.UseImmuta
     [Pure]
     private static bool IsMutable(TypeNode type)
         => type.IsArray
-        || (type.Symbol is { } symbol && IsMutable(symbol));
+        || (type.Symbol is { } symbol 
+            && !symbol.Name.StartsWith("Immutable")
+            && IsMutable(symbol));
 
     [Pure]
     private static bool IsMutable(INamedTypeSymbol type) => type


### PR DESCRIPTION
Types like `System.Collection.Immutable.ImmutableArray<T>` should be considered immutable, even if the implement `IList<T>`.