### PR TITLE
FP QW0011, QW0012: Ignore types with mutable base

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefinePropertiesAsImmutables.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefinePropertiesAsImmutables.cs
@@ -95,6 +95,13 @@ namespace Compliant
     {
         public int Value { get; set; } // Compliant {{Base class is mutable.}}
     }
+
+    public class QowaivAggregate : Qowaiv.DomainModel.Aggregate<QowaivAggregate, int>
+    {
+        public QowaivAggregate() : base(42, null) { }
+
+        public string Property { get; private set; } // Compliant {{Base class is Qowaiv Aggregate.}}
+    }
 }
 
 namespace Noncompliant

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefinePropertiesAsImmutables.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefinePropertiesAsImmutables.cs
@@ -90,6 +90,11 @@ namespace Compliant
         [Obsolete]
         public int Value { get; set; } // Compliant {{Class is obsolete.}}
     }
+
+    public class InheritsFromMutableClass : Noncompliant.Class
+    {
+        public int Value { get; set; } // Compliant {{Base class is mutable.}}
+    }
 }
 
 namespace Noncompliant

--- a/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
@@ -16,9 +16,10 @@
   </ItemGroup>
 
   <ItemGroup Label="Test Tools">
-    <PackageReference Include="CodeAnalysis.TestTools" Version="2.0.0" />
+    <PackageReference Include="CodeAnalysis.TestTools" Version="2.*" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="NuGet.Packaging" Version="6.*" />
     <PackageReference Include="NUnit" Version="4.*" />
   </ItemGroup>
 
@@ -34,7 +35,13 @@
   </ItemGroup>
 
   <ItemGroup Label="Other">
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" AllowedVersions="[4.8.0]" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
     <PackageReference Include="Qowaiv" Version="6.*" />
+    <PackageReference Include="Qowaiv.DomainModel" Version="1.*" />
+    <PackageReference Include="System.Drawing.Common" Version="8.*" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_properties_as_immutables.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_properties_as_immutables.cs
@@ -7,5 +7,7 @@ public class Verify
          => new DefinePropertiesAsImmutables()
         .ForCS()
         .AddSource(@"Cases/DefinePropertiesAsImmutables.cs")
+        .AddReference<Qowaiv.DomainModel.EventDispatcher>()
+        .AddReference<Qowaiv.Validation.Abstractions.IValidationMessage>()
         .Verify();
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -25,7 +25,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
 -v1.0.4
-- QW0011, QW0012: Ignore types with a mutable base. #35
+- QW0011, QW0012: Ignore types with a mutable base. #36
 -v1.0.3
 - QW0012: Types that have Immutable in there name are considered immutable. #34
 - QW0003: [DoesNotReturn] should be valid alternative for [Pure]. #33

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -19,11 +19,13 @@
 
   <PropertyGroup Label="Package config">
     <IsPackable>true</IsPackable>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+-v1.0.4
+- QW0011, QW0012: Ignore types with a mutable base. #35
 -v1.0.3
 - QW0012: Types that have Immutable in there name are considered immutable. #34
 - QW0003: [DoesNotReturn] should be valid alternative for [Pure]. #33
@@ -90,8 +92,8 @@ v0.0.1
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.*" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" AllowedVersions="[4.*)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.0.1" AllowedVersions="[4.*)" />
   </ItemGroup>
 
 </Project>

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsImmutables.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsImmutables.cs
@@ -1,7 +1,7 @@
 ﻿namespace Qowaiv.CodeAnalysis.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class DefinePropertiesAsImmutables() : CodingRule(Rule.DefinePropertiesAsImmutables)
+public sealed class DefinePropertiesAsImmutables() : ImmutablePropertiesBase(Rule.DefinePropertiesAsImmutables)
 {
     protected override void Register(AnalysisContext context)
         => context.RegisterSyntaxNodeAction(Report, SyntaxKind.PropertyDeclaration);
@@ -9,40 +9,15 @@ public sealed class DefinePropertiesAsImmutables() : CodingRule(Rule.DefinePrope
     private void Report(SyntaxNodeAnalysisContext context)
     {
         var property = context.Node.PropertyDeclaration(context.SemanticModel);
-        if (IsAccessable(property.Accessibility)
-            && !property.IsStatic
+        if (IsApplicable(property)
             && HasSetter(property)
-            && !property.IsObsolete
-            && IsApplicable(property.DeclaringType)
             && property.TypedNode.AccessorList!.Accessors.FirstOrDefault(a => a.IsKind(SyntaxKind.SetAccessorDeclaration)) is { } accessor)
         {
             context.ReportDiagnostic(Diagnostic, accessor);
         }
     }
 
-    private static bool IsApplicable(TypeDeclaration declaration)
-        => !declaration.Modifiers.Contains(SyntaxKind.RefKeyword)
-        && !declaration.IsObsolete
-        && IsAccessable(declaration.Accessibility)
-        && declaration.Symbol is { } declaring
-        && !IsDecorated(declaring.GetAttributes());
-
     [Pure]
     private static bool HasSetter(PropertyDeclaration declaration)
         => declaration.Accessors.Contains(SyntaxKind.SetAccessorDeclaration);
-
-    [Pure]
-    private static bool IsAccessable(Accessibility accessibility)
-        => accessibility == Accessibility.Protected
-        || accessibility == Accessibility.Public;
-
-    [Pure]
-    private static bool IsDecorated(IEnumerable<AttributeData> attributes)
-     => attributes.Any(attr => IsDecoratedAttribute(attr.AttributeClass!));
-
-    [Pure]
-    private static bool IsDecoratedAttribute(INamedTypeSymbol attr)
-       => "MUTABLE".Matches(attr.Name)
-       || "MUTABLEATTRIBUTE".Matches(attr.Name)
-       || (attr.BaseType is { } && IsDecoratedAttribute(attr.BaseType));
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/ImmutablePropertiesBase.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/ImmutablePropertiesBase.cs
@@ -1,0 +1,58 @@
+﻿namespace Qowaiv.CodeAnalysis.Rules;
+
+public abstract class ImmutablePropertiesBase(DiagnosticDescriptor supportedDiagnostic)
+    : CodingRule(supportedDiagnostic)
+{
+    [Pure]
+    protected static bool IsApplicable(PropertyDeclaration property)
+        => IsAccessible(property.Accessibility)
+        && !property.IsStatic
+        && !property.IsObsolete
+        && IsApplicable(property.DeclaringType)
+        && HasImmutableBase(property.ContainingSymbol);
+
+    [Pure]
+    private static bool IsApplicable(TypeDeclaration declaration)
+        => !declaration.Modifiers.Contains(SyntaxKind.RefKeyword)
+        && !declaration.IsObsolete
+        && IsAccessible(declaration.Accessibility)
+        && declaration.Symbol is { } declaring
+        && !IsDecorated(declaring.GetAttributes());
+
+    [Pure]
+    private static bool HasImmutableBase(INamedTypeSymbol? containing)
+    {
+        var baseType = containing?.BaseType;
+        var immutable = true;
+        while (baseType is { })
+        {
+            if (IsDecorated(baseType.GetAttributes()))
+            {
+                return true;
+            }
+            immutable &= !baseType.GetProperties().Any(IsEditable);
+            baseType = baseType.BaseType;
+        }
+        return immutable;
+    }
+
+    [Pure]
+    private static bool IsEditable(IPropertySymbol property)
+        => IsAccessible(property.DeclaredAccessibility)
+        && property.SetMethod is { };
+
+    [Pure]
+    protected static bool IsAccessible(Accessibility accessibility)
+       => accessibility == Accessibility.Protected
+       || accessibility == Accessibility.Public;
+
+    [Pure]
+    protected static bool IsDecorated(ImmutableArray<AttributeData> attributes)
+        => attributes.Any(attr => IsDecoratedAttribute(attr.AttributeClass!));
+
+    [Pure]
+    private static bool IsDecoratedAttribute(INamedTypeSymbol attr)
+       => "MUTABLE".Matches(attr.Name)
+       || "MUTABLEATTRIBUTE".Matches(attr.Name)
+       || (attr.BaseType is { } && IsDecoratedAttribute(attr.BaseType));
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
@@ -1,7 +1,7 @@
 ﻿namespace Qowaiv.CodeAnalysis.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class UseImmutableTypesForProperties() : CodingRule(Rule.UseImmutableTypesForProperties)
+public sealed class UseImmutableTypesForProperties() : ImmutablePropertiesBase(Rule.UseImmutableTypesForProperties)
 {
     protected override void Register(AnalysisContext context)
         => context.RegisterSyntaxNodeAction(Report, SyntaxKind.PropertyDeclaration);
@@ -9,10 +9,7 @@ public sealed class UseImmutableTypesForProperties() : CodingRule(Rule.UseImmuta
     private void Report(SyntaxNodeAnalysisContext context)
     {
         var property = context.Node.PropertyDeclaration(context.SemanticModel);
-        if (IsAccessable(property.Accessibility)
-            && !property.IsStatic
-            && !property.IsObsolete
-            && IsApplicable(property.DeclaringType)
+        if (IsApplicable(property)
             && IsMutable(property.PropertyType))
         {
             context.ReportDiagnostic(Diagnostic, property.PropertyType);
@@ -36,7 +33,7 @@ public sealed class UseImmutableTypesForProperties() : CodingRule(Rule.UseImmuta
 
     [Pure]
     private static IEnumerable<IPropertySymbol> AccessableProperties(ITypeSymbol type)
-        => type.GetProperties().Where(p => !p.IsStatic && IsAccessable(p.DeclaredAccessibility));
+        => type.GetProperties().Where(p => !p.IsStatic && IsAccessible(p.DeclaredAccessibility));
 
     [Pure]
     private static bool DefinesMutableInterface(ITypeSymbol type)
@@ -45,27 +42,4 @@ public sealed class UseImmutableTypesForProperties() : CodingRule(Rule.UseImmuta
             SystemType.System_Collections_Generic_IDictionary_TKey_TValue,
             SystemType.System_Collections_Generic_IList_T,
             SystemType.System_Collections_Generic_ISet_T);
-
-    [Pure]
-    private static bool IsApplicable(TypeDeclaration declaration)
-        => !declaration.Modifiers.Contains(SyntaxKind.RefKeyword)
-        && !declaration.IsObsolete
-        && IsAccessable(declaration.Accessibility)
-        && declaration.Symbol is { } declaring
-        && !IsDecorated(declaring.GetAttributes());
-
-    [Pure]
-    private static bool IsDecorated(IEnumerable<AttributeData> attributes)
-        => attributes.Any(attr => IsDecoratedAttribute(attr.AttributeClass!));
-
-    [Pure]
-    private static bool IsAccessable(Accessibility accessibility)
-        => accessibility == Accessibility.Public
-        || accessibility == Accessibility.Protected;
-
-    [Pure]
-    private static bool IsDecoratedAttribute(ITypeSymbol attr)
-        => "MUTABLE".Matches(attr.Name)
-        || "MUTABLEATTRIBUTE".Matches(attr.Name)
-        || (attr.BaseType is { } && IsDecoratedAttribute(attr.BaseType));
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/PropertyDeclaration.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/PropertyDeclaration.cs
@@ -1,11 +1,21 @@
 ﻿namespace Qowaiv.CodeAnalysis.Syntax;
 
-public sealed class PropertyDeclaration(PropertyDeclarationSyntax propertyNode, SemanticModel semanticModel)
-    : SyntaxAbstraction<IPropertySymbol>(propertyNode, semanticModel)
+public sealed class PropertyDeclaration : SyntaxAbstraction<IPropertySymbol>
 {
-    public PropertyDeclarationSyntax TypedNode { get; } = propertyNode;
+    public PropertyDeclaration(PropertyDeclarationSyntax propertyNode, SemanticModel semanticModel) : base(propertyNode, semanticModel)
+    {
+        TypedNode = propertyNode;
+        LazyContainingSymbol = new(() => Symbol?.ContainingSymbol as INamedTypeSymbol);
+    }
+
+    public PropertyDeclarationSyntax TypedNode { get; }
 
     public bool IsStatic => Modifiers.Contains(SyntaxKind.StaticKeyword);
+
+    public INamedTypeSymbol? ContainingSymbol => LazyContainingSymbol.Value;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly Lazy<INamedTypeSymbol?> LazyContainingSymbol;
 
     public IEnumerable<SyntaxKind> Modifiers => TypedNode.Modifiers.Select(m => m.Kind());
 


### PR DESCRIPTION
There is no use in reporting on types which base is already mutable, hence those should be ingored.