### PR TITLE
FP: QW0011, QW0012: Ingore IEnumerator and IXmlSerialable

### DIFF
--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefinePropertiesAsImmutables.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefinePropertiesAsImmutables.cs
@@ -23,6 +23,25 @@ namespace Compliant
         int Value { get; } // Compliant {{Interface with get only property.}}
     }
 
+    public class Iterator : System.Collections.Generic.IEnumerator<int>
+    {
+        public int Current { get; private set; }  // Compliant {{IEnumerator are ignored.}}
+        object System.Collections.IEnumerator.Current => Current;
+
+        public bool MoveNext() => true;
+        public void Dispose() { }
+        public void Reset() { }
+    }
+
+    public class XmlSerializable : System.Xml.Serialization.IXmlSerializable
+    {
+        public string Value { get; private set; } // Compliant {{IXmlSerializables are ignored.}}
+
+        public void ReadXml(System.Xml.XmlReader reader) { /* Read. */ }
+        public void WriteXml(System.Xml.XmlWriter writer) { /* Write. */ }
+        public System.Xml.Schema.XmlSchema? GetSchema() => null;
+    }
+
     public class Class
     {
         public Class(int val) => GetOnly = val;

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_properties_as_immutables.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_properties_as_immutables.cs
@@ -1,6 +1,6 @@
 ﻿namespace Rules.Define_properties_as_immutables;
 
-public class Verify
+public class Verify : System.Xml.Serialization.IXmlSerializable
 {
     [Test]
     public void Code()
@@ -9,5 +9,21 @@ public class Verify
         .AddSource(@"Cases/DefinePropertiesAsImmutables.cs")
         .AddReference<Qowaiv.DomainModel.EventDispatcher>()
         .AddReference<Qowaiv.Validation.Abstractions.IValidationMessage>()
+        .AddReference<System.Xml.Serialization.IXmlSerializable>()
         .Verify();
+
+    public System.Xml.Schema.XmlSchema? GetSchema()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ReadXml(System.Xml.XmlReader reader)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void WriteXml(System.Xml.XmlWriter writer)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
@@ -24,6 +24,22 @@ internal static class SymbolExtensions
         || (symbol?.BaseType is { } @base && @base.IsAssignableTo(type));
 
     [Pure]
+    public static bool Implements(this ITypeSymbol? symbol, SystemType @interface)
+        => symbol is { } && symbol.AllInterfaces().Any(i => i.Is(@interface));
+    //{
+    //    var faces = symbol.Interfaces.SelectMany(i => i.Interfaces).ToArray();
+
+    //    foreach (var f in faces)
+    //    {
+    //        if (f.Is(@interface))
+    //        {
+    //            return true;
+    //        }
+    //    }
+    //    return false;
+    //}
+
+    [Pure]
     public static bool IsAttribute(this ITypeSymbol type)
         => type.IsAssignableTo(SystemType.System_Attribute);
 
@@ -105,6 +121,22 @@ internal static class SymbolExtensions
         {
             yield return current;
             current = current.BaseType;
+        }
+    }
+
+    [Pure]
+    public static IEnumerable<INamedTypeSymbol> AllInterfaces(this ITypeSymbol? type)
+    {
+        if (type is null) yield break;
+
+        foreach (var @interface in type.Interfaces)
+        {
+            yield return @interface;
+
+            foreach (var sub in @interface.AllInterfaces())
+            {
+                yield return sub;
+            }
         }
     }
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -19,14 +19,16 @@
 
   <PropertyGroup Label="Package config">
     <IsPackable>true</IsPackable>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
--v1.0.4
+v1.0.5
+- QW0011, QW0012: Ingore IEnumerator and IXmlSerialable. #37
+v1.0.4
 - QW0011, QW0012: Ignore types with a mutable base. #36
--v1.0.3
+v1.0.3
 - QW0012: Types that have Immutable in there name are considered immutable. #34
 - QW0003: [DoesNotReturn] should be valid alternative for [Pure]. #33
 v1.0.2

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/ImmutablePropertiesBase.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/ImmutablePropertiesBase.cs
@@ -17,7 +17,13 @@ public abstract class ImmutablePropertiesBase(DiagnosticDescriptor supportedDiag
         && !declaration.IsObsolete
         && IsAccessible(declaration.Accessibility)
         && declaration.Symbol is { } declaring
+        && !IsExcluded(declaring)
         && !IsDecorated(declaring.GetAttributes());
+
+    [Pure]
+    public static bool IsExcluded(INamedTypeSymbol type)
+        => type.Implements(SystemType.System_Collections_IEnumerator)
+        || type.Implements(SystemType.System_Xml_Serialization_IXmlSerializable);
 
     [Pure]
     private static bool HasImmutableBase(INamedTypeSymbol? containing)

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -7,6 +7,7 @@ public partial class SystemType
     public static readonly SystemType System_DateTime = New(typeof(System.DateTime), SpecialType.System_DateTime);
     public static readonly SystemType System_Void = New(typeof(void), SpecialType.System_Void);
 
+    public static readonly SystemType System_Collections_IEnumerator = typeof(System.Collections.IEnumerator);
     public static readonly SystemType System_Collections_Generic_ICollection_T = New(typeof(System.Collections.Generic.ICollection<>), SpecialType.System_Collections_Generic_ICollection_T);
     public static readonly SystemType System_Collections_Generic_IDictionary_TKey_TValue = new("System.Collections.Generic.IDictionary<TKey, TValue>");
     public static readonly SystemType System_Collections_Generic_IList_T = New(typeof(System.Collections.Generic.IList<>), SpecialType.System_Collections_Generic_IList_T);
@@ -29,6 +30,8 @@ public partial class SystemType
 
     public static readonly SystemType System_Threading_Task = typeof(System.Threading.Tasks.Task);
     public static readonly SystemType System_Threading_ValueTask = typeof(System.Threading.Tasks.ValueTask);
+
+    public static readonly SystemType System_Xml_Serialization_IXmlSerializable = typeof(System.Xml.Serialization.IXmlSerializable);
 
     public static readonly SystemType Qowaiv_Date = new("Qowaiv.Date");
 }


### PR DESCRIPTION
Both `IEnumerator` and `IXmlSerialable` are mutable by design. Therefor, they should be ignored.