### PR TITLE
FN QW0008: Properties where not considered to decide if a struct had a well defined empty state

### DIFF
--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefinePropertiesAsNotNullable.svo.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefinePropertiesAsNotNullable.svo.cs
@@ -38,6 +38,10 @@ class Noncompliant
 
     public Nullable<Guid> Reference { get; } // Noncompliant
     //     ^^^^^^^^^^^^^^
+
+    public AsReturningProperty? AsReturningProperty { get; } // Noncompliant
+    public AsReadOnlyProperty? AsReadOnlyProperty { get; } //   Noncompliant
+    public AsField? AsField { get; } //                         Noncompliant
 }
 
 record NoncompliantRecordMultiLine(
@@ -50,6 +54,22 @@ record NoncompliantRecordMultiLine(
 record NoncompliantRecord(Guid? Id, EmailAddress? Email);
 //                        ^^^^^
 //                                  ^^^^^^^^^^^^^ @-1
+
+
+struct AsReturningProperty
+{
+    public static AsReturningProperty Empty => default;
+}
+
+struct AsReadOnlyProperty
+{
+    public static AsReadOnlyProperty Empty { get; }
+}
+
+struct AsField
+{
+    public static readonly AsField Empty;
+}
 
 struct NoMembers
 {

--- a/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" AllowedVersions="[4.8.0]" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
-    <PackageReference Include="Qowaiv" Version="6.*" />
+    <PackageReference Include="Qowaiv" Version="7.*" />
     <PackageReference Include="Qowaiv.DomainModel" Version="1.*" />
     <PackageReference Include="System.Drawing.Common" Version="8.*" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.*" />

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -24,15 +24,17 @@
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeReleased
+- QW0008: Take static read-only Empty properties into account (FN). #38
 v1.0.5
-- QW0011, QW0012: Ingore IEnumerator and IXmlSerialable. #37
+- QW0011, QW0012: Ingore IEnumerator and IXmlSerialable (FP). #37
 v1.0.4
-- QW0011, QW0012: Ignore types with a mutable base. #36
+- QW0011, QW0012: Ignore types with a mutable base (FP). #36
 v1.0.3
-- QW0012: Types that have Immutable in there name are considered immutable. #34
-- QW0003: [DoesNotReturn] should be valid alternative for [Pure]. #33
+- QW0012: Types that have Immutable in there name are considered immutable (FP). #34
+- QW0003: [DoesNotReturn] should be valid alternative for [Pure] (FP). #33
 v1.0.2
-- QW0012: Reduce FP's by ignoring potential mutable property types. #32
+- QW0012: Reduce FP's by ignoring potential mutable property types (FP). #32
 v1.0.1
 - QW0011: Define properties as immutables. #31
 - QW0012: Use immutable types for properties. #31

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsNotNullable.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsNotNullable.cs
@@ -52,15 +52,22 @@ public sealed class DefinePropertiesAsNotNullable() : CodingRule(
 
     private static DiagnosticDescriptor? DefaultIsEmpty(INamedTypeSymbol type)
     {
-        return type.GetMembers("Empty").Any(IsReadOnlyField)
+        return type.GetMembers("Empty").Any(s => IsReadOnlyProperty(s) || IsReadOnlyField(s))
             ? Rule.DefinePropertiesAsNotNullable
             : null;
 
+        static bool IsReadOnlyProperty(ISymbol member)
+            => member is IPropertySymbol prop
+            && prop.IsReadOnly
+            && prop.IsStatic
+            && prop.Type.Equals(prop.ContainingType, IncludeNullability: false)
+            && prop.IsPublic();
+
         static bool IsReadOnlyField(ISymbol member)
-           => member is IFieldSymbol field
-           && field.IsReadOnly
-           && field.IsStatic
-           && field.Type.Equals(field.ContainingType, IncludeNullability: false)
-           && field.IsPublic();
+            => member is IFieldSymbol field
+            && field.IsReadOnly
+            && field.IsStatic
+            && field.Type.Equals(field.ContainingType, IncludeNullability: false)
+            && field.IsPublic();
     }
 }


### PR DESCRIPTION
With [C# 11](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/static-virtual-interface-members) it became possible to define static (property) members. This allows code like:

``` C#
public interface IEmpty<TSelf> where TSelf : struct, IEmpty<TSelf>
{
    /// <summary>Represents an empty/not set <typeparamref name="TSelf"/>.</summary>
    static abstract TSelf Empty { get; }
}
```

As a result, it is to be expected that SVO's with a well defined empty state not only use to do so via static read-only fields, but properties as well. Hence this PR.
