### PR TITLE
New Rule: Use Qowaiv decimal rounding

### DIFF
--- a/Qowaiv.Analyzers.sln
+++ b/Qowaiv.Analyzers.sln
@@ -38,6 +38,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "rules", "rules", "{00461C52
 		rules\QW0010.md = rules\QW0010.md
 		rules\QW0011.md = rules\QW0011.md
 		rules\QW0012.md = rules\QW0012.md
+		rules\QW0013.md = rules\QW0013.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{EE67C148-3FE3-4DF4-8A91-C0BF7E3960AD}"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * [**QW0010** - Use System.DateOnly instead of Qowaiv.Date](rules/QW0010.md)
 * [**QW0011** - Define properties as immutables](rules/QW0011.md)
 * [**QW0012** - Use immutable types for properties](rules/QW0012.md)
+* [**QW0013** - Use Qowaiv decimal rounding](rules/QW0013.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))
@@ -31,3 +32,4 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * Change property type to not-nullable ([QW0008](rules/QW0008.md), [QW0009](rules/QW0009.md))
 * Change type System.DateOnly ([QW0010](rules/QW0010.md))
 * Apply suggestions of obsolete code attribute ([CS0618, CS0619])/rules/ObsoleteCode.md))
+* Use Qowiav round extensions ([QW0013](rules/QW0013.md))

--- a/rules/QW0013.md
+++ b/rules/QW0013.md
@@ -1,0 +1,29 @@
+﻿# QW0013: Use Qowaiv decimal rounding
+
+Qowaiv decimal rounding as three core benefits:
+1. Via an extenion-method, the code is easier to follow.
+2. It supports a lot more rouding methods.
+3. It allows negative values for the amount of decimals (equivalent to multiple
+   of ten, hundred, etc.).
+
+## Non-compliant
+``` C#
+public void Method(decimal value)
+{
+    decimal floor = Math.Floor(value)
+    decimal ceiling = Math.Ceiling(value)
+    decimal truncate = Math.Truncate(value)
+    decimal rounded = Math.Round(value, 3, MidpointRouding.ToEven);
+}
+```
+
+## Compliant
+``` C#
+public void Method(decimal value)
+{
+    decimal floor = value.Round(0, DecimalRounding.Floor);
+    decimal ceiling = value.Round(0, DecimalRounding.Ceiling);
+    decimal truncate = value.Round(0, DecimalRounding.Truncate);
+    decimal rounded = value.Round(3, DecimalRounding.ToEven);
+}
+```

--- a/rules/QW0013.md
+++ b/rules/QW0013.md
@@ -1,8 +1,8 @@
 ﻿# QW0013: Use Qowaiv decimal rounding
 
-Qowaiv decimal rounding as three core benefits:
-1. Via an extenion-method, the code is easier to follow.
-2. It supports a lot more rouding methods.
+Qowaiv decimal rounding has three core benefits:
+1. Via an extension-method, the code is easier to follow.
+2. It supports a lot more rounding methods.
 3. It allows negative values for the amount of decimals (equivalent to multiple
    of ten, hundred, etc.).
 

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseQowaivDecimalRounding.Fixed.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseQowaivDecimalRounding.Fixed.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+class Rounds
+{
+    public const decimal PI = 3.141592653589793238462643383279502884m;
+
+    public void Methods(decimal value)
+    {
+        _ = 3.1415m.Round();
+        _ = 3.1415m.Round(2);
+        _ = 3.1415m.Round(0, DecimalRounding.ToEven);
+        _ = 3.1415m.Round(3, DecimalRounding.ToEven);
+        _ = 3.1415m.Round(3, DecimalRounding.AwayFromZero);
+        _ = 3.1415m.Round(3, DecimalRounding.DirectTowardsZero);
+        _ = 3.1415m.Round(3, DecimalRounding.Floor);
+        _ = 3.1415m.Round(3, DecimalRounding.Ceiling);
+
+        _ = 3.1415m.Round(0, DecimalRounding.Truncate);
+        _ = 3.1415m.Round(0, DecimalRounding.Floor);
+        _ = 3.1415m.Round(0, DecimalRounding.Ceiling);
+
+        _ = PI.Round(2);
+        _ = value.Round(2);
+        _ = Math.Round(Value());
+    }
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseQowaivDecimalRounding.ToFix.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseQowaivDecimalRounding.ToFix.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+class Rounds
+{
+    public const decimal PI = 3.141592653589793238462643383279502884m;
+
+    public void Methods(decimal value)
+    {
+        _ = Math.Round(3.1415m);
+        _ = Math.Round(3.1415m, 2);
+        _ = Math.Round(3.1415m, MidpointRounding.ToEven);
+        _ = Math.Round(3.1415m, 3, MidpointRounding.ToEven);
+        _ = Math.Round(3.1415m, 3, MidpointRounding.AwayFromZero);
+        _ = Math.Round(3.1415m, 3, MidpointRounding.ToZero);
+        _ = Math.Round(3.1415m, 3, MidpointRounding.ToNegativeInfinity);
+        _ = Math.Round(3.1415m, 3, MidpointRounding.ToPositiveInfinity);
+
+        _ = Math.Truncate(3.1415m);
+        _ = Math.Floor(3.1415m);
+        _ = Math.Ceiling(3.1415m);
+
+        _ = Math.Round(PI, 2);
+        _ = Math.Round(value, 2);
+        _ = Math.Round(Value());
+    }
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseQowaivDecimalRounding.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseQowaivDecimalRounding.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+class Noncompliant
+{
+    public const decimal PI = 3.141592653589793238462643383279502884m;
+
+    void Round_on_decimal()
+    {
+        var d0 = Math.Round(3.1415m); // Noncompliant {{Use Qowaiv decimal rounding.}}
+        //       ^^^^^^^^^^^^^^^^^^^
+        var d1 = Math.Round(3.1415m, 2); // Noncompliant
+        var d2 = Math.Round(3.1415m, 3, MidpointRounding.ToEven); // Noncompliant
+    }
+
+    void Other_on_decimal()
+    {
+        var truncated = Math.Truncate(3.1415m); // Noncompliant
+        var floor = Math.Floor(3.1415m); //        Noncompliant
+        var ceiling = Math.Ceiling(3.1415m); //    Noncompliant
+    }
+
+    decimal With_constant() => Math.Round(PI); // Noncompliant
+
+    decimal With_variable(decimal value) => Math.Round(value); // Noncompliant
+}
+
+class Compliant
+{
+    void Round_on_double()
+    {
+        var d0 = Math.Round(3.1415); // Compliant
+        var d1 = Math.Round(3.1415, 2); // Compliant
+        var d2 = Math.Round(3.1415, 3, MidpointRounding.ToEven); // Compliant
+    }
+
+    void Other_on_double()
+    {
+        var truncated = Math.Truncate(3.1415); // Compliant
+        var floor = Math.Floor(3.1415); //        Compliant
+        var ceiling = Math.Ceiling(3.1415); //    Compliant
+    }
+
+    double With_constant() => Math.Round(Math.PI); // Compliant
+
+    double With_variable(double value) => Math.Round(value); // Compliant
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Fixes/Seal_class.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Fixes/Seal_class.cs
@@ -1,9 +1,9 @@
 ﻿namespace Fixes.Seal_class;
 
-public class Seal_class
+public class Fixes
 {
     [Test]
-    public void Seals_classes_and_records()
+    public void Code()
         => new SealClasses()
         .ForCS()
         .AddSource(@"Cases/SealClass.ToFix.cs")

--- a/specs/Qowaiv.CodeAnalysis.Specs/Fixes/Use_Qowaiv_Round_Extensions.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Fixes/Use_Qowaiv_Round_Extensions.cs
@@ -1,0 +1,38 @@
+﻿using Qowaiv;
+
+namespace Fixes.Use_Qowaiv_Round_Extensions;
+
+public class Fixes
+{
+    [Test]
+    public void Code()
+        => new UseQowaivDecimalRounding()
+        .ForCS()
+        .AddSource(@"Cases/UseQowaivDecimalRounding.ToFix.cs")
+        .ForCodeFix<UseQowaivRoundExtensions>()
+        .AddSource(@"Cases/UseQowaivDecimalRounding.Fixed.cs")
+        .Verify();
+}
+
+public class Rounding
+{
+    [TestCase(MidpointRounding.ToEven, DecimalRounding.ToEven)]
+    [TestCase(MidpointRounding.ToZero, DecimalRounding.DirectTowardsZero)]
+    [TestCase(MidpointRounding.AwayFromZero, DecimalRounding.AwayFromZero)]
+    [TestCase(MidpointRounding.ToPositiveInfinity, DecimalRounding.Ceiling)]
+    [TestCase(MidpointRounding.ToNegativeInfinity, DecimalRounding.Floor)]
+    public void Are_equivalent(MidpointRounding midpointRounding, DecimalRounding decimalRounding)
+    {
+        numbers.Should().AllSatisfy(n => 
+            n.Round(0, decimalRounding).Should().Be(Math.Round(n, midpointRounding), because: $"{n}"));
+    }
+
+    public static readonly decimal[] numbers =
+    [
+        -18.0m, -18.1m, -18.2m, -18.3m, -18.4m, -18.5m, -18.6m, - 18.8m, -18.9m,
+        -17.0m, -17.1m, -17.2m, -17.3m, -17.4m, -17.5m, -17.6m, - 17.8m, -17.9m,
+        +17.0m, +17.1m, +17.2m, +17.3m, +17.4m, +17.5m, +17.6m, + 17.8m, +17.9m,
+        +18.0m, +18.1m, +18.2m, +18.3m, +18.4m, +18.5m, +18.6m, + 18.8m, +18.9m,
+    ];
+}
+

--- a/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" AllowedVersions="[4.8.0]" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
-    <PackageReference Include="Qowaiv" Version="6.*" />
+    <PackageReference Include="Qowaiv" Version="7.*" />
     <PackageReference Include="Qowaiv.DomainModel" Version="1.*" />
     <PackageReference Include="System.Drawing.Common" Version="8.*" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.*" />

--- a/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" AllowedVersions="[4.8.0]" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
-    <PackageReference Include="Qowaiv" Version="7.*" />
+    <PackageReference Include="Qowaiv" Version="6.*" />
     <PackageReference Include="Qowaiv.DomainModel" Version="1.*" />
     <PackageReference Include="System.Drawing.Common" Version="8.*" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.*" />

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_Qowaiv_Decimal_Rounding.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_Qowaiv_Decimal_Rounding.cs
@@ -1,0 +1,11 @@
+﻿namespace Rules.Use_Qowaiv_Decimal_Rounding;
+
+public class Verify
+{
+    [Test]
+    public void Rule() => new UseQowaivDecimalRounding()
+        .ForCS()
+        .AddSource(@"Cases/UseQowaivDecimalRounding.cs")
+        .AddReference<Qowaiv.DecimalRounding>()
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/UseQowaivRoundExtensions.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/UseQowaivRoundExtensions.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.CodeAnalysis;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Qowaiv.CodeAnalysis.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public sealed class UseQowaivRoundExtensions() : CodeFix(Rule.UseQowaivDecimalRounding.Id)
+{
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        if (await context.ChangeDocumentContext() is { Node: InvocationExpressionSyntax syntax } change)
+        {
+            change.RegisterFix("Use Qowaiv .Round().", context, c => ApplySuggestion(syntax, c));
+        }
+    }
+
+    private static Task<Document> ApplySuggestion(InvocationExpressionSyntax syntax, ChangeDocumentContext context)
+    {
+        var list = syntax.ArgumentList.Arguments;
+        var dec = list[0].Expression;
+        var name = syntax.Expression.Name();
+        var args = Arguments(list.RemoveAt(0), name);
+
+        var member = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, dec, Round);
+        var updated = InvocationExpression(member, ArgumentList(SeparatedList(args)));
+
+        return context.ReplaceNode(syntax, updated);
+    }
+
+    private static IReadOnlyList<ArgumentSyntax> Arguments(SeparatedSyntaxList<ArgumentSyntax> args, string? method) => method switch
+    {
+        nameof(Math.Floor) or
+        nameof(Math.Ceiling) or
+        nameof(Math.Truncate) => [Zero, DecimalRounding(method)],
+        _ when args.Any() && DecimalRounding(args.Last()) is { } last => WithZero(args, last),
+        _ => args,
+    };
+
+    private static IReadOnlyList<ArgumentSyntax> WithZero(SeparatedSyntaxList<ArgumentSyntax> args, ArgumentSyntax last)
+        => args.Count == 1
+        ? [Zero, last]
+        : [args[0], last];
+
+    private static IdentifierNameSyntax Round => IdentifierName(nameof(Round));
+
+    private static ArgumentSyntax Zero => Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)));
+
+    private static ArgumentSyntax DecimalRounding(string kind) => Argument(IdentifierName($"{nameof(DecimalRounding)}.{kind}"));
+
+    private static ArgumentSyntax? DecimalRounding(ArgumentSyntax rounding)
+        => rounding is { Expression: MemberAccessExpressionSyntax { Expression: IdentifierNameSyntax expression, Name: IdentifierNameSyntax name } }
+        && expression.ToFullString().EndsWith(nameof(MidpointRounding))
+        && Kinds.TryGetValue(name.ToFullString(), out var kind)
+        ? DecimalRounding(kind)
+        : null;
+
+    private static readonly IReadOnlyDictionary<string, string> Kinds = new Dictionary<string, string>
+    {
+        ["ToEven"] = "ToEven",
+        ["ToZero"] = "DirectTowardsZero",
+        ["AwayFromZero"] = "AwayFromZero",
+        ["ToPositiveInfinity"] = "Ceiling",
+        ["ToNegativeInfinity"] = "Floor",
+    };
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/UseQowaivRoundExtensions.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/UseQowaivRoundExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+﻿using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Qowaiv.CodeAnalysis.CodeFixes;
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -19,7 +19,7 @@
 
   <PropertyGroup Label="Package config">
     <IsPackable>true</IsPackable>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -24,7 +24,8 @@
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-ToBeReleased
+v1.0.6
+- QW0013: Use Qowaiv decimal rounding (New Rule). #39
 - QW0008: Take static read-only Empty properties into account (FN). #38
 v1.0.5
 - QW0011, QW0012: Ingore IEnumerator and IXmlSerialable (FP). #37

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -130,6 +130,15 @@ public static partial class Rule
         category: Category.Design,
         tags: ["Design", "Immutability"]);
 
+    public static DiagnosticDescriptor UseQowaivDecimalRounding => New(
+        id: 0013,
+        title: "Use Qowaiv decimal rounding",
+        message: "Use Qowaiv decimal rounding.",
+        description:
+            "Both the extended functionality and the extension method are reasons to adopt Qowaiv decimal rounding.",
+        category: Category.Design,
+        tags: ["Design", "Readability"]);
+
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
     private static DiagnosticDescriptor New(

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseQowaivDecimalRounding.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseQowaivDecimalRounding.cs
@@ -1,0 +1,25 @@
+﻿namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseQowaivDecimalRounding() : CodingRule(Rule.UseQowaivDecimalRounding)
+{
+    protected override void Register(AnalysisContext context)
+        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.IdentifierName);
+
+    private void Report(SyntaxNodeAnalysisContext context)
+    {
+        if (IsMathRound(context.Node.Name())
+            && context.SemanticModel.GetSymbolInfo(context.Node).Symbol is IMethodSymbol method
+            && method.ReceiverType.Is(SystemType.System_Math)
+            && method.ReturnType.Is(SystemType.System_Decimal))
+        {
+            context.ReportDiagnostic(Diagnostic, context.Node.Parent!.Parent!);
+        }
+    }
+
+    private static bool IsMathRound(string? name)
+        => nameof(Math.Round).Equals(name)
+        || nameof(Math.Truncate).Equals(name)
+        || nameof(Math.Ceiling).Equals(name)
+        || nameof(Math.Floor).Equals(name);
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -4,6 +4,7 @@ public partial class SystemType
 {
     public static readonly SystemType System_Object = New(typeof(object), SpecialType.System_Object);
     public static readonly SystemType System_String = New(typeof(string), SpecialType.System_String);
+    public static readonly SystemType System_Decimal = New(typeof(decimal), SpecialType.System_Decimal);
     public static readonly SystemType System_DateTime = New(typeof(System.DateTime), SpecialType.System_DateTime);
     public static readonly SystemType System_Void = New(typeof(void), SpecialType.System_Void);
 
@@ -23,6 +24,7 @@ public partial class SystemType
     public static readonly SystemType System_DateTimeOffset = typeof(System.DateTimeOffset);
     public static readonly SystemType System_Exception = typeof(System.Exception);
     public static readonly SystemType System_IDisposable = typeof(System.IDisposable);
+    public static readonly SystemType System_Math = typeof(System.Math);
     public static readonly SystemType System_ObsoleteAttribute = typeof(System.ObsoleteAttribute);
 
     public static readonly SystemType System_Diagnostics_CodeAnalysis_DoesNotReturnAttribute = new("System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute");

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
@@ -14,6 +14,7 @@ public sealed partial class SystemType
     public string ShortName { get; }
 
     public SpecialType Type { get; }
+    
 
     internal bool Matches(string fullName)
         => Type == SpecialType.None


### PR DESCRIPTION
When considering: `Math.Round(someValue, 4)` and `someValue.Round(4)` that latter is preferred. Besides that, Qowaiv's alternative also allows: `someValue.Round(2, DecimalRounding.Floor)` and a lot of other rounding strategies.
