### PR TITLE
New Rule: Define global using statements separately

### DIFF
--- a/Qowaiv.Analyzers.sln
+++ b/Qowaiv.Analyzers.sln
@@ -39,6 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "rules", "rules", "{00461C52
 		rules\QW0011.md = rules\QW0011.md
 		rules\QW0012.md = rules\QW0012.md
 		rules\QW0013.md = rules\QW0013.md
+		rules\QW0014.md = rules\QW0014.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{EE67C148-3FE3-4DF4-8A91-C0BF7E3960AD}"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * [**QW0011** - Define properties as immutables](rules/QW0011.md)
 * [**QW0012** - Use immutable types for properties](rules/QW0012.md)
 * [**QW0013** - Use Qowaiv decimal rounding](rules/QW0013.md)
+* [**QW0014** - Define global using statements separately](rules/QW0014.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))
@@ -32,4 +33,4 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * Change property type to not-nullable ([QW0008](rules/QW0008.md), [QW0009](rules/QW0009.md))
 * Change type System.DateOnly ([QW0010](rules/QW0010.md))
 * Apply suggestions of obsolete code attribute ([CS0618, CS0619])/rules/ObsoleteCode.md))
-* Use Qowiav round extensions ([QW0013](rules/QW0013.md))
+* Use Qowaiv round extensions ([QW0013](rules/QW0013.md))

--- a/rules/QW0014.md
+++ b/rules/QW0014.md
@@ -1,0 +1,22 @@
+﻿# QW0014: Define global using statements separately
+
+Defining using statements globally is wonderful way of reducing using statements
+in code files. To keep things maintainable, however, it is advised to have
+dedicated code files that only contain global using statements and no global
+using statements elsewhere.
+
+## Non-compliant
+``` C#
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+
+.. any other code
+```
+
+## Compliant
+``` C#
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+```

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineGlobalUsingStatementsSeparately.GlobalUsings.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineGlobalUsingStatementsSeparately.GlobalUsings.cs
@@ -1,0 +1,5 @@
+﻿global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Text;
+global using System.Threading.Tasks; // Compliant

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineGlobalUsingStatementsSeparately.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineGlobalUsingStatementsSeparately.cs
@@ -1,0 +1,6 @@
+﻿global using System.Collections; // Noncompliant ^0#32 {{Define global using statement in a separate file.}}
+global using static System.Math; // Noncompliant
+global using TXT = System.Text; //  Noncompliant
+using System.Collections.Generic;
+
+public class Other { }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Specs</RootNamespace>
     <OutputType>library</OutputType>
   </PropertyGroup>
-
+ 
   <ItemGroup>
     <Compile Remove="Cases/*.*" />
     <None Include="Cases/*.*">

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_global_using_statements_separately.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_global_using_statements_separately.cs
@@ -1,0 +1,16 @@
+﻿namespace Rules.Define_global_using_statements_separately;
+
+public class Verify
+{
+    [Test]
+    public void Rule_for_only_globals() => new DefineGlobalUsingStatementsSeparately()
+        .ForCS()
+        .AddSource(@"Cases/DefineGlobalUsingStatementsSeparately.GlobalUsings.cs")
+        .Verify();
+
+    [Test]
+    public void Rule_with_mix() => new DefineGlobalUsingStatementsSeparately()
+        .ForCS()
+        .AddSource(@"Cases/DefineGlobalUsingStatementsSeparately.cs")
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -24,6 +24,8 @@
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeReleased
+- QW0014: Define global using statements separately (New Rule). #40
 v1.0.6
 - QW0013: Use Qowaiv decimal rounding (New Rule). #39
 - QW0008: Take static read-only Empty properties into account (FN). #38

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -139,6 +139,15 @@ public static partial class Rule
         category: Category.Design,
         tags: ["Design", "Readability"]);
 
+    public static DiagnosticDescriptor DefineGlobalUsingStatementsSeparately => New(
+        id: 0014,
+        title: "Define global using statements separately",
+        message: "Define global using statement in a separate file.",
+        description:
+            "For design and maintainability reasons, it is key that all global usings statements are grouped.",
+        category: Category.Design,
+        tags: ["Design", "Maintainability"]);
+
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
     private static DiagnosticDescriptor New(

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatementsSeparately.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatementsSeparately.cs
@@ -1,0 +1,25 @@
+﻿
+namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DefineGlobalUsingStatementsSeparately() : CodingRule(Rule.DefineGlobalUsingStatementsSeparately)
+{
+    protected override void Register(AnalysisContext context)
+        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.UsingDirective);
+
+    private void Report(SyntaxNodeAnalysisContext context)
+    {
+        if (IsGlobalDirective(context.Node) && !AllGobal(context.Node))
+        {
+            context.ReportDiagnostic(Diagnostic, context.Node);
+        }
+    }
+
+    private static bool AllGobal(SyntaxNode node)
+        => node.Parent is CompilationUnitSyntax root
+        && root.ChildNodes().All(IsGlobalDirective);
+
+    private static bool IsGlobalDirective(SyntaxNode node)
+        => node is UsingDirectiveSyntax direcive
+        && direcive.ChildTokens().Any(token => token.IsKind(SyntaxKind.GlobalKeyword));
+}


### PR DESCRIPTION
Defining using statements globally is wonderful way of reducing using statements in code files. To keep things maintainable, however, it is advised to have dedicated code files that only contain global using statements and no global using statements elsewhere.