### PR TITLE
Define global using statements in single file

### DIFF
--- a/Qowaiv.Analyzers.sln
+++ b/Qowaiv.Analyzers.sln
@@ -40,6 +40,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "rules", "rules", "{00461C52
 		rules\QW0012.md = rules\QW0012.md
 		rules\QW0013.md = rules\QW0013.md
 		rules\QW0014.md = rules\QW0014.md
+		rules\QW0015.md = rules\QW0015.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{EE67C148-3FE3-4DF4-8A91-C0BF7E3960AD}"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/Qowaiv/qowaiv-analyzers/blob/main/CODE_OF_CONDUCT.md)
 ![Build Status](https://github.com/Qowaiv/qowaiv-analyzers/workflows/Build%20%26%20Test/badge.svg?branch=main)
 
-| version                                                              | downloads                                                   | package                                                                           |
-|----------------------------------------------------------------------|-------------------------------------------------------------|-----------------------------------------------------------------------------------|
-|![v](https://img.shields.io/nuget/v/Qowaiv.Analyzers.CSharp?color=18C)|![v](https://img.shields.io/nuget/dt/Qowaiv.Analyzers.CSharp)|[QQowaiv.Analyzers.CSharp](https://www.nuget.org/packages/Qowaiv.Analyzers.CSharp/)|
+| version                                                              | downloads                                                   | package                                                                          |
+|----------------------------------------------------------------------|-------------------------------------------------------------|----------------------------------------------------------------------------------|
+|![v](https://img.shields.io/nuget/v/Qowaiv.Analyzers.CSharp?color=18C)|![v](https://img.shields.io/nuget/dt/Qowaiv.Analyzers.CSharp)|[Qowaiv.Analyzers.CSharp](https://www.nuget.org/packages/Qowaiv.Analyzers.CSharp/)|
 
 # Qowaiv (static code) analyzers
 Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
@@ -26,6 +26,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * [**QW0012** - Use immutable types for properties](rules/QW0012.md)
 * [**QW0013** - Use Qowaiv decimal rounding](rules/QW0013.md)
 * [**QW0014** - Define global using statements separately](rules/QW0014.md)
+* [**QW0015** - Define global using statements in single file](rules/QW0015.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))

--- a/rules/QW0015.md
+++ b/rules/QW0015.md
@@ -1,0 +1,16 @@
+﻿# QW0015: Define global using statements in single file
+
+Defining using statements globally is wonderful way of reducing using statements
+in code files. To keep things maintainable, however, all global using statements
+should be defined in a single file. This rule prefers `"Properties/GlobalUsings.cs"`.
+
+The reason for this location is, that Visual Studio (and other IDE's for C#)
+show the `Properties` folder differently than other directories, and it are,
+that you could argue that it are properties from a compiler perspective.
+
+## Configuration
+If desired, another location can be configured:
+
+``` INI
+dotnet_diagnostic.QW0015.GlobalUsingsFile = Usings.cs
+```

--- a/rules/QW0015.md
+++ b/rules/QW0015.md
@@ -2,11 +2,11 @@
 
 Defining using statements globally is wonderful way of reducing using statements
 in code files. To keep things maintainable, however, all global using statements
-should be defined in a single file. This rule prefers `"Properties/GlobalUsings.cs"`.
+should be defined in a single file.
 
-The reason for this location is, that Visual Studio (and other IDE's for C#)
-show the `Properties` folder differently than other directories, and it are,
-that you could argue that it are properties from a compiler perspective.
+By default, this rule prefers `"Properties/GlobalUsings.cs"`.  Visual Studio
+(and other IDE's for C#) consider `Properties` a special directory, which is
+displayed differently. This helps finding the global using statements.e.
 
 ## Configuration
 If desired, another location can be configured:

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineGlobalUsingStatementsInSingleFile.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineGlobalUsingStatementsInSingleFile.cs
@@ -1,0 +1,3 @@
+﻿global using System; // Noncompliant ^0#20 {{Define global using statements in 'Properties/GlobalUsings.cs' only.}}
+global using System.Collections.Generic; // Noncompliant
+

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/GlobalUsings.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/GlobalUsings.cs
@@ -1,0 +1,3 @@
+﻿global using System;
+global using System.Collections.Generic;
+global using System.Linq;

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_global_using_statements_in_single_file.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_global_using_statements_in_single_file.cs
@@ -1,0 +1,16 @@
+﻿namespace Rules.Define_global_using_statements_in_single_file;
+
+public class Verify
+{
+    [Test]
+    public void Properties_GlobalUsings_cs() => new DefineGlobalUsingStatementsInSingleFile("Cases/GlobalUsings.cs")
+        .ForCS()
+        .AddSource(@"Cases/GlobalUsings.cs")
+        .Verify();
+
+    [Test]
+    public void Other_location() => new DefineGlobalUsingStatementsInSingleFile()
+        .ForCS()
+        .AddSource(@"Cases/DefineGlobalUsingStatementsInSingleFile.cs")
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext.cs
@@ -37,5 +37,4 @@ internal static class SyntaxNodeAnalysisContextExtensions
             .TryGetValue($"dotnet_diagnostic.{descriptor.Id}.{property}", out var value)
             ? value
             : null;
-
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext.cs
@@ -26,4 +26,16 @@ internal static class SyntaxNodeAnalysisContextExtensions
                 descriptor,
                 token.GetLocation(),
                 messageArgs));
+
+    /// <summary>Tries to read the `dotnet_diagnostic.{descriptor.Id}.{property}` option.</summary>
+    public static string? TryGetConfiguredProperty(
+        this SyntaxNodeAnalysisContext context,
+        DiagnosticDescriptor descriptor,
+        string property)
+        => context.Options.AnalyzerConfigOptionsProvider
+            .GetOptions(context.Node.SyntaxTree)
+            .TryGetValue($"dotnet_diagnostic.{descriptor.Id}.{property}", out var value)
+            ? value
+            : null;
+
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
@@ -26,18 +26,6 @@ internal static class SymbolExtensions
     [Pure]
     public static bool Implements(this ITypeSymbol? symbol, SystemType @interface)
         => symbol is { } && symbol.AllInterfaces().Any(i => i.Is(@interface));
-    //{
-    //    var faces = symbol.Interfaces.SelectMany(i => i.Interfaces).ToArray();
-
-    //    foreach (var f in faces)
-    //    {
-    //        if (f.Is(@interface))
-    //        {
-    //            return true;
-    //        }
-    //    }
-    //    return false;
-    //}
 
     [Pure]
     public static bool IsAttribute(this ITypeSymbol type)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -19,12 +19,13 @@
 
   <PropertyGroup Label="Package config">
     <IsPackable>true</IsPackable>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-ToBeReleased
+v1.0.7
+- QW0015: Define global using statements in single file (New Rule). #41
 - QW0014: Define global using statements separately (New Rule). #40
 v1.0.6
 - QW0013: Use Qowaiv decimal rounding (New Rule). #39

--- a/src/Qowaiv.CodeAnalysis.CSharp/README.md
+++ b/src/Qowaiv.CodeAnalysis.CSharp/README.md
@@ -13,6 +13,9 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) (s
 * [**QW0010** - Use System.DateOnly instead of Qowaiv.Date](rules/QW0010.md)
 * [**QW0011** - Define properties as immutables](rules/QW0011.md)
 * [**QW0012** - Use immutable types for properties](rules/QW0012.md)
+* [**QW0013** - Use Qowaiv decimal rounding](rules/QW0013.md)
+* [**QW0014** - Define global using statements separately](rules/QW0014.md)
+* [**QW0015** - Define global using statements in single file](rules/QW0015.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))
@@ -20,3 +23,4 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) (s
 * Change property type to not-nullable ([QW0008](rules/QW0008.md), [QW0009](rules/QW0009.md))
 * Change type System.DateOnly ([QW0010](rules/QW0010.md))
 * Apply suggestions of obsolete code attribute ([CS0618, CS0619])/rules/ObsoleteCode.md))
+* Use Qowaiv round extensions ([QW0013](rules/QW0013.md))

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -142,7 +142,16 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineGlobalUsingStatementsSeparately => New(
         id: 0014,
         title: "Define global using statements separately",
-        message: "Define global using statement in a separate file.",
+        message: "Define global using statements in a separate file.",
+        description:
+            "For design and maintainability reasons, it is key that all global usings statements are grouped.",
+        category: Category.Design,
+        tags: ["Design", "Maintainability"]);
+
+    public static DiagnosticDescriptor DefineGlobalUsingStatementsInSingleFile => New(
+        id: 0015,
+        title: "Define global using statements in single file",
+        message: "Define global using statements in '{0}' only.",
         description:
             "For design and maintainability reasons, it is key that all global usings statements are grouped.",
         category: Category.Design,

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -142,7 +142,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineGlobalUsingStatementsSeparately => New(
         id: 0014,
         title: "Define global using statements separately",
-        message: "Define global using statements in a separate file.",
+        message: "Define global using statement in a separate file.",
         description:
             "For design and maintainability reasons, it is key that all global usings statements are grouped.",
         category: Category.Design,

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatements.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatements.cs
@@ -1,0 +1,14 @@
+﻿namespace Qowaiv.CodeAnalysis.Rules;
+
+public abstract class DefineGlobalUsingStatements(DiagnosticDescriptor supportedDiagnostic)
+    : CodingRule(supportedDiagnostic)
+{
+    protected override void Register(AnalysisContext context)
+        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.UsingDirective);
+
+    protected abstract void Report(SyntaxNodeAnalysisContext context);
+
+    protected static bool IsGlobalDirective(SyntaxNode node)
+       => node is UsingDirectiveSyntax direcive
+       && direcive.ChildTokens().Any(token => token.IsKind(SyntaxKind.GlobalKeyword));
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatementsInSingleFile.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatementsInSingleFile.cs
@@ -1,0 +1,29 @@
+﻿namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DefineGlobalUsingStatementsInSingleFile(string globalConfigFile)
+    : DefineGlobalUsingStatements(Rule.DefineGlobalUsingStatementsInSingleFile)
+{
+    public DefineGlobalUsingStatementsInSingleFile() : this("Properties/GlobalUsings.cs") { }
+
+    private readonly string GlobalUsingsFile = globalConfigFile;
+
+    protected override void Report(SyntaxNodeAnalysisContext context)
+    {
+        if (IsGlobalDirective(context.Node))
+        {
+            var globalConfig = context.TryGetConfiguredProperty(Diagnostic, nameof(GlobalUsingsFile)) ?? GlobalUsingsFile;
+
+            if (IsDifferentFile(context.Node.SyntaxTree.FilePath, globalConfig))
+            {
+                context.ReportDiagnostic(Diagnostic, context.Node, globalConfig);
+            }
+        }
+    }
+
+    private static bool IsDifferentFile(string? filepath, string globalConfig)
+        => Split(filepath) is not { Length: > 0 } splitted
+        || !splitted.SequenceEqual(Split(globalConfig));
+
+    private static string[] Split(string? path) => (path ?? string.Empty).Split('/', '\\');
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatementsSeparately.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatementsSeparately.cs
@@ -1,13 +1,9 @@
-﻿
-namespace Qowaiv.CodeAnalysis.Rules;
+﻿namespace Qowaiv.CodeAnalysis.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class DefineGlobalUsingStatementsSeparately() : CodingRule(Rule.DefineGlobalUsingStatementsSeparately)
+public sealed class DefineGlobalUsingStatementsSeparately() : DefineGlobalUsingStatements(Rule.DefineGlobalUsingStatementsSeparately)
 {
-    protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.UsingDirective);
-
-    private void Report(SyntaxNodeAnalysisContext context)
+    protected override void Report(SyntaxNodeAnalysisContext context)
     {
         if (IsGlobalDirective(context.Node) && !AllGobal(context.Node))
         {
@@ -18,8 +14,4 @@ public sealed class DefineGlobalUsingStatementsSeparately() : CodingRule(Rule.De
     private static bool AllGobal(SyntaxNode node)
         => node.Parent is CompilationUnitSyntax root
         && root.ChildNodes().All(IsGlobalDirective);
-
-    private static bool IsGlobalDirective(SyntaxNode node)
-        => node is UsingDirectiveSyntax direcive
-        && direcive.ChildTokens().Any(token => token.IsKind(SyntaxKind.GlobalKeyword));
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
@@ -14,7 +14,6 @@ public sealed partial class SystemType
     public string ShortName { get; }
 
     public SpecialType Type { get; }
-    
 
     internal bool Matches(string fullName)
         => Type == SpecialType.None


### PR DESCRIPTION
Defining using statements globally is wonderful way of reducing using statements in code files. To keep things maintainable, however, all global using statements should be defined in a single file. This rule prefers `"Properties/GlobalUsings.cs"`.

The reason for this location is, that Visual Studio (and other IDE's for C#) show the `Properties` folder differently than other directories, and it are, that you could argue that it are properties from a compiler perspective.

## Configuration
If desired, another location can be configured:

``` INI
dotnet_diagnostic.QW0015.GlobalUsingsFile = Usings.cs
```
