### PR TITLE
New Rule: Prefer regular over positional properties

### DIFF
--- a/Qowaiv.Analyzers.sln
+++ b/Qowaiv.Analyzers.sln
@@ -41,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "rules", "rules", "{00461C52
 		rules\QW0013.md = rules\QW0013.md
 		rules\QW0014.md = rules\QW0014.md
 		rules\QW0015.md = rules\QW0015.md
+		rules\QW0016.md = rules\QW0016.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{EE67C148-3FE3-4DF4-8A91-C0BF7E3960AD}"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * [**QW0013** - Use Qowaiv decimal rounding](rules/QW0013.md)
 * [**QW0014** - Define global using statements separately](rules/QW0014.md)
 * [**QW0015** - Define global using statements in single file](rules/QW0015.md)
+* [**QW0016** - Prefer regular over positional properties](rules/QW0016.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))

--- a/rules/QW0016.md
+++ b/rules/QW0016.md
@@ -1,8 +1,8 @@
 ﻿# QW0016: Prefer regular over positional properties 
 
-With the release of C# 10, [`record`'s](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/record)
-have been introduced. One of the advocated advantages is possibility to use a
-so called primary constructor which allows to define a full data structure in
+With the release of C# 10, [`record`](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/record)'s
+have been introduced. One of the advocated advantages is the possibility to use
+a so called primary constructor which allows to define a full data structure in
 a single line:
 
 ``` C#

--- a/rules/QW0016.md
+++ b/rules/QW0016.md
@@ -1,0 +1,34 @@
+﻿# QW0016: Prefer regular over positional properties 
+
+With the release of C# 10, [`record`'s](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/record)
+have been introduced. One of the advocated advantages is possibility to use a
+so called primary constructor which allows to define a full data structure in
+a single line:
+
+``` C#
+record MyRecord(string Message, string Other);
+```
+
+However powerful, for (public) API's it turns out to be not that practical:
+Defining attributes, having numerous (Let say 3 or more) properties, or
+documentation, turns out to be counter intuitive and cumbersome.
+
+Therefor this rule reports on primary constructors on public records, and 
+provides code fix to help refactoring.
+
+## Non-compliant
+``` C#
+public record DataStructure(string Required, object? Optional, int WIth Default = 42);
+```
+
+## Compliant
+``` C#
+public record DataStructure
+{
+    public required string Required { get; init; }
+    
+    public object? Optional { get; init; }
+    
+    public int WIth Default { get; init; } =  42
+}
+````

--- a/rules/QW0016.md
+++ b/rules/QW0016.md
@@ -18,7 +18,7 @@ provides code fix to help refactoring.
 
 ## Non-compliant
 ``` C#
-public record DataStructure(string Required, object? Optional, int WIth Default = 42);
+public record DataStructure(string Required, object? Optional, int WithDefault = 42);
 ```
 
 ## Compliant
@@ -29,6 +29,6 @@ public record DataStructure
     
     public object? Optional { get; init; }
     
-    public int WIth Default { get; init; } =  42
+    public int WithDefault { get; init; } =  42
 }
 ````

--- a/rules/QW0016.md
+++ b/rules/QW0016.md
@@ -14,7 +14,7 @@ Defining attributes or adding documentation turns out to be counterintuitive and
 cumbersome." "Having numerous properties (let's say 3 or more) also makes it
 less readable.
 
-Therefor this rule reports on primary constructors on public records, and 
+Therefore this rule reports on primary constructors on public records, and 
 provides a code fix to help refactoring.
 
 ## Non-compliant

--- a/rules/QW0016.md
+++ b/rules/QW0016.md
@@ -2,19 +2,20 @@
 
 With the release of C# 10, [`record`](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/record)'s
 have been introduced. One of the advocated advantages is the possibility to use
-a so called primary constructor which allows to define a full data structure in
-a single line:
+a so called primary constructor which allows you to define a full data structure
+in a single line:
 
 ``` C#
 record MyRecord(string Message, string Other);
 ```
 
-However powerful, for (public) API's it turns out to be not that practical:
-Defining attributes, having numerous (Let say 3 or more) properties, or
-documentation, turns out to be counter intuitive and cumbersome.
+However powerful, for (public) APIs it turns out to be not that practical:
+Defining attributes or adding documentation turns out to be counterintuitive and
+cumbersome." "Having numerous properties (let's say 3 or more) also makes it
+less readable.
 
 Therefor this rule reports on primary constructors on public records, and 
-provides code fix to help refactoring.
+provides a code fix to help refactoring.
 
 ## Non-compliant
 ``` C#

--- a/rules/QW0016.md
+++ b/rules/QW0016.md
@@ -11,7 +11,7 @@ record MyRecord(string Message, string Other);
 
 However powerful, for (public) APIs it turns out to be not that practical:
 Defining attributes or adding documentation turns out to be counterintuitive and
-cumbersome." "Having numerous properties (let's say 3 or more) also makes it
+cumbersome. Having numerous properties (let's say 3 or more) also makes it
 less readable.
 
 Therefore this rule reports on primary constructors on public records, and 

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ConvertPositionalProperties.Fixed.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ConvertPositionalProperties.Fixed.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+public record WithoutBody()
+{
+    public required string Message { get; init; }
+}
+
+public record WithBody()
+{
+    public string Trimmed => Message.Trim();
+
+    public required string Message { get; init; }
+}
+
+public record WithDefault()
+{
+    public required string Message { get; init; } = "default";
+}
+
+public record WithOptional()
+{
+    public string? Message { get; init; }
+}
+
+public record WithMultiple()
+{
+    public int? Value0 { get; init; }
+
+    public required int Value1 { get; init; }
+
+    public required string Value2 { get; init; }
+
+    public string? Value3 { get; init; } = "help";
+}
+
+public sealed record WithAttribute()
+{
+    [Prop]
+    public required object First { get; init; }
+
+    [Prop]
+    public required string Second { get; init; }
+}
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class PropAttribute : Attribute { }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ConvertPositionalProperties.ToFix.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ConvertPositionalProperties.ToFix.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+public record WithoutBody(string Message);
+
+public record WithBody(string Message)
+{
+    public string Trimmed => Message.Trim();
+}
+
+public record WithDefault(string Message = "default");
+
+public record WithOptional(string? Message);
+
+public record WithMultiple(int? Value0, int Value1, string Value2, string? Value3 = "help");
+
+public sealed record WithAttribute([Prop] object First, [property: Prop] string Second);
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class PropAttribute : Attribute { }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/PreferRegularOverPositionalProperties.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/PreferRegularOverPositionalProperties.cs
@@ -1,0 +1,23 @@
+﻿namespace Noncompliant
+{
+    public record PreferRegular(
+        string Required, //             Noncompliant {{Define Required as a required property.}}
+        string? Optional, //            Noncompliant {{Define Optional as a regular property.}}
+        string? Default = "default");// Noncompliant {{Define Default as a property with a default value.}}
+
+    public record PreferRequiredMultipleProperties(string Message, int Value)
+    //                                             ^^^^^^^^^^^^^^
+    //                                                             ^^^^^^^^^ @-1
+    {
+    }
+}
+
+namespace Compliant
+{
+    public class ClassWithPrimary(string value) { }
+
+    public record RecordWithoutPrimary
+    {
+        public string Message { get; init; }
+    }
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Fixes/Convert_positional_properties.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Fixes/Convert_positional_properties.cs
@@ -1,0 +1,13 @@
+﻿namespace Fixes.Convert_positional_properties;
+
+public class Fixes
+{
+    [Test]
+    public void Code()
+        => new PreferRegularOverPositionalProperties()
+        .ForCS()
+        .AddSource(@"Cases/ConvertPositionalProperties.ToFix.cs")
+        .ForCodeFix<ConvertPositionalProperties>()
+        .AddSource(@"Cases/ConvertPositionalProperties.Fixed.cs")
+        .Verify();
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Prefer_regular_over_positional_properties.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Prefer_regular_over_positional_properties.cs
@@ -1,0 +1,11 @@
+﻿namespace Rules.Prefer_regular_over_positional_properties;
+
+public class Verify
+{
+    [Test]
+    public void Code()
+         => new PreferRegularOverPositionalProperties()
+        .ForCS()
+        .AddSource(@"Cases/PreferRegularOverPositionalProperties.cs")
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/ConvertPositionalProperties.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/ConvertPositionalProperties.cs
@@ -1,0 +1,73 @@
+﻿using Qowaiv.CodeAnalysis.Rules;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxKind;
+
+namespace Qowaiv.CodeAnalysis.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public sealed class ConvertPositionalProperties() : CodeFix(Rule.PreferRegularOverPositionalProperties.Id)
+{
+    public async override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        if (await context.ChangeDocumentContext() is { Node: ParameterSyntax parameter } change)
+        {
+            change.RegisterFix("Convert to regular property.", context, d => Change(parameter, d));
+        }
+    }
+
+    private static Task<Document> Change(ParameterSyntax parameter, ChangeDocumentContext context)
+    {
+        var parameters = (ParameterListSyntax)parameter.Parent!;
+        var declaration = (RecordDeclarationSyntax)parameters.Parent!;
+
+        var parameterTrivia = parameter.GetLeadingTrivia();
+
+        var property = PropertyDeclaration(parameter.Type!, parameter.Identifier)
+            .AddModifiers(parameter)
+            .AddAccessors()
+            .AddAttributes(parameter.AttributeLists)
+            .WithDefault(parameter.Default)
+            .WithLeadingTrivia(parameterTrivia.Insert(0, LineFeed));
+
+        var updated = declaration
+            .WithBraces()
+            .WithParameterList(ParameterList(parameters.Parameters.Remove(parameter)))
+            .AddMembers(property);
+
+        return context.ReplaceNode(declaration, updated);
+    }
+}
+
+file static class Extensions
+{
+    public static PropertyDeclarationSyntax AddModifiers(this PropertyDeclarationSyntax property, ParameterSyntax param)
+        => PreferRegularOverPositionalProperties.NotNull(param)
+        ? property.AddModifiers(Token(PublicKeyword), Token(SyntaxKindExt.RequiredKeyword))
+        : property.AddModifiers(Token(PublicKeyword));
+
+    public static PropertyDeclarationSyntax AddAccessors(this PropertyDeclarationSyntax property) => property
+        .AddAccessorListAccessors(
+            AccessorDeclaration(GetAccessorDeclaration).WithSemicolonToken(Token(SemicolonToken)),
+            AccessorDeclaration(InitAccessorDeclaration).WithSemicolonToken(Token(SemicolonToken)));
+
+    public static PropertyDeclarationSyntax AddAttributes(this PropertyDeclarationSyntax property, SyntaxList<AttributeListSyntax> list)
+    {
+        var attrs = list.SelectMany(l => l.Attributes)
+            .Select(attr => AttributeList(SeparatedList(attr.Singleton())));
+
+        return attrs.Any()
+            ? property.WithAttributeLists(new(attrs))
+            : property;
+    }
+
+    public static PropertyDeclarationSyntax WithDefault(this PropertyDeclarationSyntax property, EqualsValueClauseSyntax? @default)
+        => @default is { }
+        ? property.WithInitializer(@default)
+            .WithSemicolonToken(Token(SemicolonToken))
+        : property;
+
+    public static RecordDeclarationSyntax WithBraces(this RecordDeclarationSyntax record) => record
+        .WithOpenBraceToken(Token(OpenBraceToken))
+        .WithCloseBraceToken(Token(CloseBraceToken))
+        .WithSemicolonToken(default);
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/LanguageVersionExt.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/LanguageVersionExt.cs
@@ -1,0 +1,6 @@
+﻿namespace Qowaiv.CodeAnalysis;
+
+internal static class LanguageVersionExt
+{
+    public static readonly LanguageVersion CSharp11 = (LanguageVersion)1100;
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -19,18 +19,20 @@
 
   <PropertyGroup Label="Package config">
     <IsPackable>true</IsPackable>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+v1.0.9
+- QW0016: Locations are commonly past through as full paths (NEW RULE). #45
 v1.0.8
 - QW0015: Locations are commonly past through as full paths (FP). #42
 v1.0.7
-- QW0015: Define global using statements in single file (New Rule). #41
-- QW0014: Define global using statements separately (New Rule). #40
+- QW0015: Define global using statements in single file (NEW RULE). #41
+- QW0014: Define global using statements separately (NEW RULE). #40
 v1.0.6
-- QW0013: Use Qowaiv decimal rounding (New Rule). #39
+- QW0013: Use Qowaiv decimal rounding (NEW RULE). #39
 - QW0008: Take static read-only Empty properties into account (FN). #38
 v1.0.5
 - QW0011, QW0012: Ingore IEnumerator and IXmlSerialable (FP). #37

--- a/src/Qowaiv.CodeAnalysis.CSharp/README.md
+++ b/src/Qowaiv.CodeAnalysis.CSharp/README.md
@@ -16,6 +16,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) (s
 * [**QW0013** - Use Qowaiv decimal rounding](rules/QW0013.md)
 * [**QW0014** - Define global using statements separately](rules/QW0014.md)
 * [**QW0015** - Define global using statements in single file](rules/QW0015.md)
+* [**QW0016** - Prefer regular over positional properties](rules/QW0016.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))
@@ -24,3 +25,4 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) (s
 * Change type System.DateOnly ([QW0010](rules/QW0010.md))
 * Apply suggestions of obsolete code attribute ([CS0618, CS0619])/rules/ObsoleteCode.md))
 * Use Qowaiv round extensions ([QW0013](rules/QW0013.md))
+* Convert positional properties ([QW0016](rules/QW0016.md))

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -158,6 +158,17 @@ public static partial class Rule
         category: Category.Design,
         tags: ["Design", "Maintainability"]);
 
+    public static DiagnosticDescriptor PreferRegularOverPositionalProperties => New(
+        id: 0016,
+        title: "Prefer regular over positional properties",
+        message: "Define {0} as {1}.",
+        description:
+            "The usage of positional properties, defined in a primary constructor, " +
+            "turns out to be cumbersome for public API's. Therefor the use of " +
+            "regular properties is preferred in those cases.",
+        category: Category.Design,
+        tags: ["Design", "Maintainability"]);
+
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
     private static DiagnosticDescriptor New(

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -164,7 +164,7 @@ public static partial class Rule
         message: "Define {0} as {1}.",
         description:
             "The usage of positional properties, defined in a primary constructor, " +
-            "turns out to be cumbersome for public API's. Therefor the use of " +
+            "turns out to be cumbersome for public APIs. Therefor the use of " +
             "regular properties is preferred in those cases.",
         category: Category.Design,
         tags: ["Design", "Maintainability"]);

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/PreferRegularOverPositionalProperties.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/PreferRegularOverPositionalProperties.cs
@@ -1,0 +1,32 @@
+﻿
+namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PreferRegularOverPositionalProperties() : CodingRule(Rule.PreferRegularOverPositionalProperties)
+{
+    protected override void Register(AnalysisContext context)
+        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.RecordDeclaration);
+
+    private void Report(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Compilation.LanguageVersion() >= LanguageVersionExt.CSharp11
+            && context.Node is RecordDeclarationSyntax declaration
+            && declaration.ParameterList is { } list)
+        {
+            foreach (var parameter in list.Parameters)
+            {
+                context.ReportDiagnostic(Diagnostic, parameter, parameter.Identifier, Message(parameter));
+            }
+        }
+    }
+
+    private static string Message(ParameterSyntax parameter) => parameter switch
+    {
+        _ when parameter.Default is { } => "a property with a default value",
+        _ when NotNull(parameter) => "a required property",
+        _ => "a regular property",
+    };
+
+    internal static bool NotNull(ParameterSyntax parameter)
+        => parameter.Type is not NullableTypeSyntax;
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/SyntaxKindExt.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SyntaxKindExt.cs
@@ -1,0 +1,6 @@
+﻿namespace Qowaiv.CodeAnalysis;
+
+internal static class SyntaxKindExt
+{
+    public static readonly SyntaxKind RequiredKeyword = (SyntaxKind)8447;
+}


### PR DESCRIPTION
With the release of C# 10, [`record`](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/record)'s have been introduced. One of the advocated advantages is possibility to use a so called primary constructor which allows to define a full data structure in a single line:

``` C#
record MyRecord(string Message, string Other);
```

However powerful, for (public) API's it turns out to be not that practical: Defining attributes, having numerous (Let say 3 or more) properties, or documentation, turns out to be counter intuitive and cumbersome.

Therefor this rule reports on primary constructors on public records, and provides code fix to help refactoring.

## Non-compliant
``` C#
public record DataStructure(string Required, object? Optional, int WIth Default = 42);
```

## Compliant
``` C#
public record DataStructure
{
    public required string Required { get; init; }
    
    public object? Optional { get; init; }
    
    public int WIth Default { get; init; } =  42
}
````


See: #44