### PR TITLE
Depend on Microsoft.CodeAnalysis 4.10.0

### DIFF
--- a/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Test Tools">
-    <PackageReference Include="CodeAnalysis.TestTools" Version="2.*" />
+    <PackageReference Include="CodeAnalysis.TestTools" Version="3.*" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="NuGet.Packaging" Version="6.*" />
@@ -35,9 +35,9 @@
   </ItemGroup>
 
   <ItemGroup Label="Other">
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" AllowedVersions="[4.8.0]" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" AllowedVersions="[4.8.0]" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.*" />
     <PackageReference Include="Qowaiv" Version="7.*" />
     <PackageReference Include="Qowaiv.DomainModel" Version="1.*" />
     <PackageReference Include="System.Drawing.Common" Version="8.*" />

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -19,11 +19,13 @@
 
   <PropertyGroup Label="Package config">
     <IsPackable>true</IsPackable>
-    <Version>1.0.9</Version>
+    <Version>2.0.0</Version>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+v2.0.0
+- Depend on Microsoft.CodeAnalysis 4.10.0 (potential breaking). #46
 v1.0.9
 - QW0016: Locations are commonly past through as full paths (NEW RULE). #45
 v1.0.8
@@ -104,8 +106,8 @@ v0.0.1
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" AllowedVersions="[4.*)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.0.1" AllowedVersions="[4.*)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" AllowedVersions="[4.10.*)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0" AllowedVersions="[4.10.*)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Previously, `Qowaiv.Analyzers` was dependent on [v4.0.1](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Common/4.0.1), a version release on November 2021.

This version depends on [v4.10.0](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Common/4.10.0), released June 2024.