### PR TITLE
FP QW0016: Obsolete code and calls to bases should be excluded

### DIFF
--- a/Qowaiv.Analyzers.sln
+++ b/Qowaiv.Analyzers.sln
@@ -51,8 +51,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build-test.yaml = .github\workflows\build-test.yaml
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeAnalysis.TestTools", "..\roslyn-test-tools\src\CodeAnalysis.TestTools\CodeAnalysis.TestTools.csproj", "{7E716F0B-A464-4B97-BF83-14E45655BD2D}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -67,10 +65,6 @@ Global
 		{D9C004D3-B8F6-47DD-AFF3-60C579868F97}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9C004D3-B8F6-47DD-AFF3-60C579868F97}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9C004D3-B8F6-47DD-AFF3-60C579868F97}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7E716F0B-A464-4B97-BF83-14E45655BD2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7E716F0B-A464-4B97-BF83-14E45655BD2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7E716F0B-A464-4B97-BF83-14E45655BD2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7E716F0B-A464-4B97-BF83-14E45655BD2D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Qowaiv.Analyzers.sln
+++ b/Qowaiv.Analyzers.sln
@@ -51,6 +51,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build-test.yaml = .github\workflows\build-test.yaml
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeAnalysis.TestTools", "..\roslyn-test-tools\src\CodeAnalysis.TestTools\CodeAnalysis.TestTools.csproj", "{7E716F0B-A464-4B97-BF83-14E45655BD2D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{D9C004D3-B8F6-47DD-AFF3-60C579868F97}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9C004D3-B8F6-47DD-AFF3-60C579868F97}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9C004D3-B8F6-47DD-AFF3-60C579868F97}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E716F0B-A464-4B97-BF83-14E45655BD2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E716F0B-A464-4B97-BF83-14E45655BD2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E716F0B-A464-4B97-BF83-14E45655BD2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E716F0B-A464-4B97-BF83-14E45655BD2D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ConvertPositionalProperties.Fixed.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ConvertPositionalProperties.Fixed.cs
@@ -42,5 +42,13 @@ public sealed record WithAttribute()
     public required string Second { get; init; }
 }
 
+public sealed record ChildRecord(string Message) : BaseRecord(Message)
+{
+    public string? Extra { get; init; }
+}
+
+[Obsolete]
+public abstract record BaseRecord(string Message);
+
 [AttributeUsage(AttributeTargets.Property)]
 public sealed class PropAttribute : Attribute { }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ConvertPositionalProperties.ToFix.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ConvertPositionalProperties.ToFix.cs
@@ -15,5 +15,10 @@ public record WithMultiple(int? Value0, int Value1, string Value2, string? Value
 
 public sealed record WithAttribute([Prop] object First, [property: Prop] string Second);
 
+public sealed record ChildRecord(string? Extra, string Message) : BaseRecord(Message);
+
+[Obsolete]
+public abstract record BaseRecord(string Message);
+
 [AttributeUsage(AttributeTargets.Property)]
 public sealed class PropAttribute : Attribute { }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/PreferRegularOverPositionalProperties.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/PreferRegularOverPositionalProperties.cs
@@ -10,14 +10,26 @@
     //                                                             ^^^^^^^^^ @-1
     {
     }
+
+    public sealed record Inherit(string New, string BaseProp) : Base(BaseProp);
+    //                           ^^^^^^^^^^
+
+    public record Base(string BaseProp); // Noncompliant
 }
 
 namespace Compliant
 {
+    public sealed record Inherit(string BaseProp) : Base(BaseProp); // Compliant {{Can only besolved after the base has been fixed.}}
+
+    public record Base(string BaseProp); // Noncompliant
+
     public class ClassWithPrimary(string value) { }
 
     public record RecordWithoutPrimary
     {
         public string Message { get; init; }
     }
+
+    [System.Obsolete]
+    public record ObsoleteCode(string Message);
 }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Test Tools">
-    <PackageReference Include="CodeAnalysis.TestTools" Version="3.*" />
+    <PackageReference Include="CodeAnalysis.TestTools" Version="3.0.1" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="NuGet.Packaging" Version="6.*" />
@@ -38,6 +38,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0" />
     <PackageReference Include="Qowaiv" Version="7.*" />
     <PackageReference Include="Qowaiv.DomainModel" Version="1.*" />
     <PackageReference Include="System.Drawing.Common" Version="8.*" />
@@ -46,6 +49,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj" />
+    <ProjectReference Include="..\..\..\roslyn-test-tools\src\CodeAnalysis.TestTools\CodeAnalysis.TestTools.csproj" />
   </ItemGroup>
 
 </Project>

--- a/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
@@ -49,7 +49,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj" />
-    <ProjectReference Include="..\..\..\roslyn-test-tools\src\CodeAnalysis.TestTools\CodeAnalysis.TestTools.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.SyntaxNode.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.SyntaxNode.cs
@@ -8,10 +8,12 @@ public static class SyntaxNodeExtensions
     [Pure]
     public static string? Name(this SyntaxNode node) => node switch
     {
+        ArgumentSyntax arg => Name(arg.Expression),
         AttributeSyntax attr => Name(attr.Name),
         IdentifierNameSyntax identifier => identifier.Identifier.Text,
         InvocationExpressionSyntax invocation => Name(invocation.Expression),
         MemberAccessExpressionSyntax memberAccess => Name(memberAccess.Name),
+        ParameterSyntax param => param.Identifier.Text,
         SimpleNameSyntax simpleName => simpleName.Identifier.Text,
         NameSyntax name => name.ToFullString(),
         _ => null,

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -26,6 +26,7 @@
     <PackageReleaseNotes>
 v2.0.0
 - Depend on Microsoft.CodeAnalysis 4.10.0 (potential breaking). #46
+- QW0016: Obsolete code and required by base parameters should be ignored (FP). #47
 v1.0.9
 - QW0016: Locations are commonly past through as full paths (NEW RULE). #45
 v1.0.8
@@ -108,6 +109,8 @@ v0.0.1
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" AllowedVersions="[4.10.*)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0" AllowedVersions="[4.10.*)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" AllowedVersions="[4.*)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0" AllowedVersions="[4.*)" />
   </ItemGroup>
 
 </Project>

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/TypeDeclaration.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/TypeDeclaration.cs
@@ -33,7 +33,8 @@ public abstract partial class TypeDeclaration : SyntaxAbstraction<INamedTypeSymb
     public bool IsPartial => Modifiers.Contains(SyntaxKind.PartialKeyword);
 
     public bool IsObsolete
-        => Symbol is { } symbol
+        => (IsPartial || Attributes.Any())
+        && Symbol is { } symbol
         && symbol.IsObsolete();
 
     public abstract IEnumerable<SyntaxKind> Modifiers { get; }


### PR DESCRIPTION
If a record is decorated as being obsolete, we do not want to be bothered with this kind of design suggestions. Also, when the base record requires it, it is simply not possible to convert positional properties to regular ones.