### PR TITLE
New Rule: Apply arithmetic operations on non-nullables only

### DIFF
--- a/Qowaiv.Analyzers.sln
+++ b/Qowaiv.Analyzers.sln
@@ -42,6 +42,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "rules", "rules", "{00461C52
 		rules\QW0014.md = rules\QW0014.md
 		rules\QW0015.md = rules\QW0015.md
 		rules\QW0016.md = rules\QW0016.md
+		rules\QW0017.md = rules\QW0017.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{EE67C148-3FE3-4DF4-8A91-C0BF7E3960AD}"

--- a/rules/QW0017.md
+++ b/rules/QW0017.md
@@ -1,0 +1,16 @@
+﻿# QW0017: Apply arithmetic operations on non-nullables only 
+
+.NET allows arithmetic operations between nullable value types. The outcome of
+those operations will potentially by `null` if any of the operants has no value
+runtime. This behavior is commonly undesirable, and occurrences are not trivial
+to spot, potentially leading to bugs.
+## Non-compliant
+
+``` C#
+var sum = model.Child?.Amount + model.Other.Total;
+```
+
+## Compliant
+``` C#
+var sum = (model.Child?.Amount ?? 0) + model.Other.Total;
+````

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ApplyArithmeticOperationsOnNonNullablesOnly.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ApplyArithmeticOperationsOnNonNullablesOnly.cs
@@ -1,0 +1,88 @@
+﻿
+using Qowaiv.Financial;
+
+class Noncompliant
+{
+    void LeftIsNullable(decimal? left)
+    {
+        var result = left + 42m; // Noncompliant
+        //           ^^^^
+    }
+
+    void RightIsNullable(decimal? right)
+    {
+        var result = 42 + right; // Noncompliant
+        //                ^^^^^
+    }
+
+    void BothAreNullable(decimal? left, decimal? right)
+    {
+        var result = left + right; // Noncompliant
+        //           ^^^^^^^^^^^^
+    }
+
+    void AllOperators(decimal? left)
+    {
+        var add = left + 42; //       Noncompliant
+        var subtract = left - 42; //  Noncompliant
+        var multiply = left * 42; //  Noncompliant
+        var divide = left / 42; //    Noncompliant
+        var remainder = left % 42; // Noncompliant
+    }
+
+    void OtherTypes()
+    {
+        var amount = 42.Amount() + default(Amount?); // Noncompliant;
+        var dlb = 42.0 + default(double?); //           Noncompliant;
+    }
+
+    void Assignment(decimal? value)
+    {
+        decimal? x = 42;
+        x += value; // Noncompliant
+//      ^^^^^^^^^^
+        x -= value; // Noncompliant
+        x *= value; // Noncompliant
+        x /= value; // Noncompliant
+        x %= value; // Noncompliant
+    }
+
+    void Assignment(decimal? init, decimal value)
+    {
+        init += value; // Noncompliant
+//      ^^^^
+    }
+}
+
+class Compliant
+{
+    void BothNotNullable(decimal left, decimal right)
+    {
+        var result = left + right;
+    }
+
+    void AllOperators(decimal left)
+    {
+        var add = left + 42;
+        var subtract = left - 42;
+        var multiply = left * 42;
+        var divide = left / 42;
+        var remainder = left % 42;
+    }
+
+    void OtherTypes()
+    {
+        var amount = 42.Amount() + 3.14.Amount();
+        var dlb = 42.0 + System.Math.PI;
+    }
+
+    void Assignment(decimal value)
+    {
+        decimal x = 42;
+        x += value;
+        x -= value;
+        x *= value;
+        x /= value;
+        x %= value;
+    }
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/ApplyArithmeticOperationsOnNonNullablesOnly.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/ApplyArithmeticOperationsOnNonNullablesOnly.cs
@@ -5,19 +5,19 @@ class Noncompliant
 {
     void LeftIsNullable(decimal? left)
     {
-        var result = left + 42m; // Noncompliant
+        var result = left + 42m; // Noncompliant {{Value of operand is potentially null.}}
         //           ^^^^
     }
 
     void RightIsNullable(decimal? right)
     {
-        var result = 42 + right; // Noncompliant
+        var result = 42 + right; // Noncompliant {{Value of operand is potentially null.}}
         //                ^^^^^
     }
 
     void BothAreNullable(decimal? left, decimal? right)
     {
-        var result = left + right; // Noncompliant
+        var result = left + right; // Noncompliant {{Result of operation is potentially null.}}
         //           ^^^^^^^^^^^^
     }
 

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Apply_arithmetic_operations_on_non_nullables_only.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Apply_arithmetic_operations_on_non_nullables_only.cs
@@ -1,0 +1,12 @@
+﻿namespace Rules.Apply_arithmetic_operations_on_non_nullables_only;
+
+public class Verify
+{
+    [Test]
+    public void Code()
+         => new ApplyArithmeticOperationsOnNonNullablesOnly()
+        .ForCS()
+        .AddSource(@"Cases/ApplyArithmeticOperationsOnNonNullablesOnly.cs")
+        .AddReference<Qowaiv.Financial.Amount>()
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/Category.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/Category.cs
@@ -2,6 +2,8 @@
 
 public enum Category
 {
+    Bug,
+
     Design,
 
     [Display("Runtime Error")]

--- a/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/CodingRule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/CodingRule.cs
@@ -2,11 +2,8 @@
 
 public abstract class CodingRule : DiagnosticAnalyzer
 {
-    protected CodingRule(DiagnosticDescriptor supportedDiagnostic)
-        => SupportedDiagnostics = ImmutableArray.Create(supportedDiagnostic);
-
     protected CodingRule(DiagnosticDescriptor supportedDiagnostic, params DiagnosticDescriptor[] additional)
-        => SupportedDiagnostics = ImmutableArray.Create(supportedDiagnostic.Singleton().Concat(additional).ToArray());
+        => SupportedDiagnostics = [supportedDiagnostic, ..additional];
 
     public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -23,12 +23,14 @@
 
   <PropertyGroup Label="Package config">
     <IsPackable>true</IsPackable>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
+v2.0.3
+- QW0017: Apply arithmetic operations on non-nullables only (NEW RULE). #51
 v2.0.2
 - QW0011, QW0012: Improve messages. #50 
 v2.0.1

--- a/src/Qowaiv.CodeAnalysis.CSharp/README.md
+++ b/src/Qowaiv.CodeAnalysis.CSharp/README.md
@@ -17,6 +17,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) (s
 * [**QW0014** - Define global using statements separately](rules/QW0014.md)
 * [**QW0015** - Define global using statements in single file](rules/QW0015.md)
 * [**QW0016** - Prefer regular over positional properties](rules/QW0016.md)
+* [**QW0017** - Apply arithmetic operations on non-nullables only ](rules/QW0017.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -172,7 +172,7 @@ public static partial class Rule
     public static DiagnosticDescriptor ApplyArithmeticOperationsOnNonNullablesOnly => New(
         id: 17,
         title: "Apply arithmetic operations on non-nullables only",
-        message: "This arithmetic operation potentially has null result.",
+        message: "{0} is potentially null.",
         description:
             ".NET allows arithmetic operations between nullable value types. The " +
             "outcome will be null if any of the arguments turns out to be null, " +

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -169,6 +169,17 @@ public static partial class Rule
         category: Category.Design,
         tags: ["Design", "Maintainability"]);
 
+    public static DiagnosticDescriptor ApplyArithmeticOperationsOnNonNullablesOnly => New(
+        id: 17,
+        title: "Apply arithmetic operations on non-nullables only",
+        message: "This arithmetic operation potentially has null result.",
+        description:
+            ".NET allows arithmetic operations between nullable value types. The " +
+            "outcome will be null if any of the arguments turns out to be null, " +
+            "which can be confusing or a bug.",
+        category: Category.Bug,
+        tags: ["nullabillity", "arithmetic"]);
+
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
     private static DiagnosticDescriptor New(

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/ArithmeticArgumentsShouldHaveValue.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/ArithmeticArgumentsShouldHaveValue.cs
@@ -1,0 +1,54 @@
+﻿
+namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ApplyArithmeticOperationsOnNonNullablesOnly() : CodingRule(Rule.ApplyArithmeticOperationsOnNonNullablesOnly)
+{
+    protected override void Register(AnalysisContext context)
+    {
+        context.RegisterSyntaxNodeAction(
+            Report,
+            SyntaxKind.MultiplyExpression,
+            SyntaxKind.DivideExpression,
+            SyntaxKind.AddExpression,
+            SyntaxKind.SubtractExpression,
+            SyntaxKind.ModuloExpression,
+            // Assignments
+            SyntaxKind.MultiplyAssignmentExpression,
+            SyntaxKind.DivideAssignmentExpression,
+            SyntaxKind.AddAssignmentExpression,
+            SyntaxKind.SubtractAssignmentExpression,
+            SyntaxKind.ModuloAssignmentExpression);
+    }
+
+    private void Report(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is BinaryExpressionSyntax binary
+            && Nullable(binary.Left,binary.Right) is { } nullBinary)
+        {
+            context.ReportDiagnostic(Diagnostic, nullBinary);
+        }
+        else if (context.Node is AssignmentExpressionSyntax assign
+             && Nullable(assign.Left, assign.Right) is { } nullAssign)
+        {
+            context.ReportDiagnostic(Diagnostic, nullAssign);
+        }
+
+        SyntaxNode? Nullable(ExpressionSyntax left, ExpressionSyntax right)
+        {
+            var l = IsNullable(left);
+            var r = IsNullable(right);
+
+            return context switch
+            {
+                _ when l && r => context.Node,
+                _ when l => left,
+                _ when r => right,
+                _ => null,
+            };
+        }
+
+        bool IsNullable(ExpressionSyntax expression)
+            => context.SemanticModel.GetTypeInfo(expression).Type?.IsNullableValueType() is true;
+    }
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemDateOnly.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemDateOnly.cs
@@ -1,10 +1,8 @@
 ﻿namespace Qowaiv.CodeAnalysis.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class UseSystemDateOnly : CodingRule
+public sealed class UseSystemDateOnly() : CodingRule(Rule.UseSystemDateOnly)
 {
-    public UseSystemDateOnly() : base(Rule.UseSystemDateOnly) { }
-
     protected override void Register(AnalysisContext context)
     {
         context.RegisterSyntaxNodeAction(ReportField, SyntaxKind.FieldDeclaration);


### PR DESCRIPTION
To prevent unexpected outcomes in arithmetic operations. 