### PR TITLE
QW0100: Define only one Required attribute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 [*]
 end_of_line = crlf
 insert_final_newline = true
+charset = utf-8
 
 [*.bat]
 end_of_line = lf
@@ -21,87 +22,3 @@ indent_size = 2
 
 vsspell_section_id = main
 vsspell_ignored_words_main = File:dictionary.dic
-
-dotnet_diagnostic.IDE1006.severity = none # IDE1006: Naming Styles
-
-dotnet_diagnostic.CA1069.severity = warning # Enums values should not be duplicated
-dotnet_diagnostic.CA1806.severity = warning # Do not ignore method results
-dotnet_diagnostic.CA1816.severity = warning # Dispose methods should call SuppressFinalize
-dotnet_diagnostic.CA1822.severity = warning # Member that does not access instance data can be marked as static
-dotnet_diagnostic.CA1825.severity = warning # Avoid zero-length array allocations
-dotnet_diagnostic.CA2016.severity = warning # Forward the 'CancellationToken' parameter to methods
-dotnet_diagnostic.CA2211.severity = warning # Non-constant fields should not be visible
-dotnet_diagnostic.CA2231.severity = warning # Overload operator equals on overriding value type Equals
-dotnet_diagnostic.CA2254.severity = warning # Template should be a static expression
-
-dotnet_diagnostic.CA1860.severity = none    #  Prefer comparing 'Length' to 0 rather than using 'Any()'
-
-dotnet_diagnostic.S100.severity  = none     # Properties should be named in PascalCase
-dotnet_diagnostic.S101.severity  = none     # Types should be named in PascalCase
-dotnet_diagnostic.S3376.severity = none     # Attribute, EventArgs, and Exception type names should end with the type being extended
-dotnet_diagnostic.S4136.severity = none     # All method overloads should be adjacent.
-
-dotnet_diagnostic.S107.severity  = warning  # Methods should not have too many parameters
-dotnet_diagnostic.S1144.severity = warning  # Unused private types or members should be removed
-dotnet_diagnostic.S1185.severity = warning  # Overriding members should do more than simply call the same member in the base class
-dotnet_diagnostic.S1479.severity = warning  # Consider reworking this 'switch' to reduce the number of 'case's to at most 30
-dotnet_diagnostic.S1858.severity = warning  # "ToString()" calls should not be redundant
-dotnet_diagnostic.S1694.severity = warning  # Convert this 'abstract' class to a concrete type with a protected constructor.
-dotnet_diagnostic.S2302.severity = warning  # "nameof" should be used
-dotnet_diagnostic.S2342.severity = warning  # Rename this enumeration to match naming convention
-dotnet_diagnostic.S2436.severity = warning  # Types and methods should not have too many generic parameters
-dotnet_diagnostic.S3215.severity = warning  # interface instances should not be cast to concrete types
-dotnet_diagnostic.S3218.severity = warning  # Rename this property to not shadow the outer class' member with the same name																														   
-dotnet_diagnostic.S3257.severity = warning  # Declarations and initializations should be as concise as possible
-dotnet_diagnostic.S3776.severity = warning  # Cognitive Complexity of methods should not be too high
-dotnet_diagnostic.S3925.severity = warning  # "ISerializable" should be implemented correctly
-dotnet_diagnostic.S6354.severity = warning  # Use a testable Time Provider
-
-dotnet_diagnostic.SA0001.severity = none # XML comment analysis disabled.
-dotnet_diagnostic.SA1001.severity = none # Commas should not be preceded by whitespace.
-dotnet_diagnostic.SA1101.severity = none # Prefix local calls with this.
-dotnet_diagnostic.SA1127.severity = none # Generic type constraints should be on their own line.
-dotnet_diagnostic.SA1128.severity = none # Constructor initializes should be on their own line.
-dotnet_diagnostic.SA1200.severity = none # using directive is placed outside of a namespace element.
-dotnet_diagnostic.SA1201.severity = none # Order of different members.
-dotnet_diagnostic.SA1202.severity = none # Sort members based on visibillity.
-dotnet_diagnostic.SA1203.severity = none # Constants before non-constants.
-dotnet_diagnostic.SA1204.severity = none # Sort members based on static/instance.
-dotnet_diagnostic.SA1208.severity = none # System using directives must be placed before other using directives.
-dotnet_diagnostic.SA1214.severity = none # Sort readonly fields before non-readonly fields.
-dotnet_diagnostic.SA1300.severity = none # Enum members should not start with lower-case character.
-dotnet_diagnostic.SA1302.severity = none # Interface names should start with an I.
-dotnet_diagnostic.SA1304.severity = none # None-private fields should begin with upper-case character.
-dotnet_diagnostic.SA1306.severity = none # Fields should begin with lower-case character.
-dotnet_diagnostic.SA1307.severity = none # Fields should begin with upper-case character.
-dotnet_diagnostic.SA1308.severity = none # Fields should begin with 'm_' prefix.
-dotnet_diagnostic.SA1309.severity = none # Fields should begin with underscore.
-dotnet_diagnostic.SA1310.severity = none # Fields should not contain underscores.
-dotnet_diagnostic.SA1311.severity = none # Static read-only fields should begin with upper-case character.
-dotnet_diagnostic.SA1313.severity = none # Parameters should begin with lower-case letter. (Due to FP on _)
-dotnet_diagnostic.SA1402.severity = none # File may only contain a single type
-dotnet_diagnostic.SA1502.severity = none # Element should not be on single line.
-dotnet_diagnostic.SA1503.severity = none # Braces should not be omitted.
-dotnet_diagnostic.SA1513.severity = none # Closing brace should be followed by an empty line.
-dotnet_diagnostic.SA1519.severity = none # Braces should not be omitted from multi-line childe statement.
-dotnet_diagnostic.SA1520.severity = none # Use braces consistently.
-dotnet_diagnostic.SA1600.severity = none # Elements should be documented.
-dotnet_diagnostic.SA1601.severity = none # Partial elements should be documented.
-dotnet_diagnostic.SA1602.severity = none # Enumerations should be documented.
-dotnet_diagnostic.SA1611.severity = none # The documentation for parameter x is missing.
-dotnet_diagnostic.SA1615.severity = none # The documentation return value.
-dotnet_diagnostic.SA1618.severity = none # The documentation type parameter.
-dotnet_diagnostic.SA1623.severity = none # The property's documentation summary text should begin with: 'Gets'.
-dotnet_diagnostic.SA1633.severity = none # The file header is missing or not located at the top of the file.
-dotnet_diagnostic.SA1636.severity = none # The file header should contain match copyright from settings.
-dotnet_diagnostic.SA1637.severity = none # The file header should contain file name.
-dotnet_diagnostic.SA1640.severity = none # The copyright tag should contain a non-empty company attribute.
-dotnet_diagnostic.SA1649.severity = none # File name should match first type name.
-
-dotnet_diagnostic.SA1401.severity = suggestion # Fields should be private.
-dotnet_diagnostic.SA1407.severity = suggestion # Arithmetic expressions should declare precedence.
-dotnet_diagnostic.SA1501.severity = suggestion # Statement should not be on single line.
-dotnet_diagnostic.SA1512.severity = suggestion # Single-line comment should be followed by blank line.
-dotnet_diagnostic.SA1515.severity = suggestion # Single-line comment should be preceded by blank line.
-
-dotnet_diagnostic.SYSLIB1045.severity = warning # Use 'GeneratedRegexAttribute' to generate the regular expression implementation at compile-time

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * [**QW0016** - Prefer regular over positional properties](rules/QW0016.md)
 * [**QW0017** - Apply arithmetic operations on non-nullables only](rules/QW0017.md)
 
+### Data Annotation rules
+* [**QW0100** - Define only one Required attribute](rules/QW0100.md)
+
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))
 * Seal class ([QW0005](rules/QW0005.md))

--- a/rules/QW0100.md
+++ b/rules/QW0100.md
@@ -1,0 +1,33 @@
+# QW0100: Define only one Required attribute
+
+The `[Required]` attribute is designed to be used in isolation. It usage is
+defined as follows:
+
+``` C#
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+```
+
+The reasoning for this is, that if the required constraint is not met, no
+further validation is done. When `[Required]` is overridden (by `[Any]`,
+`[Mandatory]`,  `[Optional]`, or whatever which implementation) this constraint
+should still apply but the compiler will not longer enforce this, hence this
+rule.
+
+## Non-compliant
+``` C#
+class Model
+{
+    [Any]
+    [Required]
+    public int[] Numbers { get; init; }
+}
+```
+
+## Compliant
+``` C#
+class Model
+{
+    [Any]
+    public int[] Numbers { get; init; }
+}
+````

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineOnlyOneRequiredAttribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineOnlyOneRequiredAttribute.cs
@@ -1,0 +1,42 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+class Model
+{
+    [Required]
+    public string WithSingle { get; init; }
+
+    [Optional]
+    public string WithOptional { get; init; }
+
+    [Required]
+    [Optional] // Noncompliant {{WithMultiple should not be decorated with more than one required attribute}} 
+//   ^^^^^^^^
+    public string WithMultiple { get; init; }
+
+    [Required, Optional] // Noncompliant
+//             ^^^^^^^^
+    public string WithMultipleInLine { get; init; }
+
+    public string WithoutAttributes { get; init; }
+
+    [StringLength(1024)]
+    [Display(Name = "With other Attributes")]
+    public string WithOtherAttributes { get; init; }
+
+    [StringLength(1024)]
+    [Display(Name = "With other Attributes")]
+    [Optional]
+    public string WithSingleAndOthers { get; init; }
+
+    [StringLength(1024)]
+    [Display(Name = "With other Attributes")]
+    [Optional]
+    [Required] // Noncompliant
+    public string WithMultipleAndOthers { get; init; }
+}
+
+
+public sealed class OptionalAttribute : RequiredAttribute
+{
+    public override bool IsValid(object? value) => true;
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineOnlyOneRequiredAttribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineOnlyOneRequiredAttribute.cs
@@ -35,14 +35,16 @@ class OnProperties
     public string WithMultipleAndOthers { get; init; }
 }
 
-class onFields
+class OnFields
 {
     [Required]
     [Optional] // Noncompliant {{WithMultiple should not be decorated with more than one required attribute}} 
-               //   ^^^^^^^^
+//   ^^^^^^^^
     public string WithMultiple;
 }
 
+record OnRecords([Required, Optional] string WithMultiple, [Required] string WithSingle); // Noncompliant {{WithMultiple should not be decorated with more than one required attribute}} 
+//                          ^^^^^^^^
 
 public sealed class OptionalAttribute : RequiredAttribute
 {

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineOnlyOneRequiredAttribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineOnlyOneRequiredAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-class Model
+class OnProperties
 {
     [Required]
     public string WithSingle { get; init; }
@@ -33,6 +33,14 @@ class Model
     [Optional]
     [Required] // Noncompliant
     public string WithMultipleAndOthers { get; init; }
+}
+
+class onFields
+{
+    [Required]
+    [Optional] // Noncompliant {{WithMultiple should not be decorated with more than one required attribute}} 
+               //   ^^^^^^^^
+    public string WithMultiple;
 }
 
 

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineOnlyOneRequiredAttribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/DefineOnlyOneRequiredAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 class OnProperties
 {

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_only_one_Required_attribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_only_one_Required_attribute.cs
@@ -1,4 +1,4 @@
-﻿namespace Rules.Define_only_one_Required_attribute;
+namespace Rules.Define_only_one_Required_attribute;
 
 public class Verify
 {

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_only_one_Required_attribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_only_one_Required_attribute.cs
@@ -3,7 +3,7 @@
 public class Verify
 {
     [Test]
-    public void Properties_with_value_types() => new DefineOnlyOneRequiredAttribute()
+    public void Required_properties() => new DefineOnlyOneRequiredAttribute()
         .ForCS()
         .AddSource(@"Cases/DefineOnlyOneRequiredAttribute.cs")
         .AddReference<System.ComponentModel.DataAnnotations.RequiredAttribute>()

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_only_one_Required_attribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Define_only_one_Required_attribute.cs
@@ -1,0 +1,11 @@
+﻿namespace Rules.Define_only_one_Required_attribute;
+
+public class Verify
+{
+    [Test]
+    public void Properties_with_value_types() => new DefineOnlyOneRequiredAttribute()
+        .ForCS()
+        .AddSource(@"Cases/DefineOnlyOneRequiredAttribute.cs")
+        .AddReference<System.ComponentModel.DataAnnotations.RequiredAttribute>()
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.SyntaxNode.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.SyntaxNode.cs
@@ -6,10 +6,11 @@ public static class SyntaxNodeExtensions
         => node.AncestorsAndSelf().OfType<TNode>().FirstOrDefault();
 
     [Pure]
-    public static string? Name(this SyntaxNode node) => node switch
+    public static string? Name(this SyntaxNode? node) => node switch
     {
         ArgumentSyntax n /*...............*/ => Name(n.Expression),
         AttributeSyntax n /*..............*/ => Name(n.Name),
+        FieldDeclarationSyntax n /*.......*/ => Name(n.Declaration),
         IdentifierNameSyntax n /*.........*/ => n.Identifier.Text,
         InvocationExpressionSyntax n /*...*/ => Name(n.Expression),
         MemberAccessExpressionSyntax n /*.*/ => Name(n.Name),
@@ -17,6 +18,8 @@ public static class SyntaxNodeExtensions
         SimpleNameSyntax n /*.............*/ => n.Identifier.Text,
         NameSyntax n /*...................*/ => n.ToFullString(),
         PropertyDeclarationSyntax n /*....*/ => n.Identifier.Text,
+        VariableDeclarationSyntax n /*....*/ => Name(n.Variables.FirstOrDefault()),
+        VariableDeclaratorSyntax n /*.....*/ => n.Identifier.Text,
         _ => null,
     };
 
@@ -41,6 +44,20 @@ public static class SyntaxNodeExtensions
         InterfaceDeclarationSyntax @interface => new TypeDeclaration.Interface(@interface, model),
         RecordDeclarationSyntax record => new TypeDeclaration.Record(record, model),
         StructDeclarationSyntax @struct => new TypeDeclaration.Struct(@struct, model),
+        _ => null,
+    };
+
+    [Pure]
+    public static MemberDeclaration MemberDeclaration(this SyntaxNode node, SemanticModel model)
+        => TryMemberDeclaration(node, model)
+        ?? throw new InvalidOperationException($"Unexpected {node.GetType().Name}, expected a member declaration.");
+
+    [Pure]
+    public static MemberDeclaration? TryMemberDeclaration(this SyntaxNode node, SemanticModel model) => node switch
+    {
+        FieldDeclarationSyntax field => new MemberDeclaration.Field(field, model),
+        ParameterSyntax param => new MemberDeclaration.Parameter(param, model),
+        PropertyDeclarationSyntax prop => new MemberDeclaration.Property(prop, model),
         _ => null,
     };
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.SyntaxNode.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.SyntaxNode.cs
@@ -8,14 +8,15 @@ public static class SyntaxNodeExtensions
     [Pure]
     public static string? Name(this SyntaxNode node) => node switch
     {
-        ArgumentSyntax arg => Name(arg.Expression),
-        AttributeSyntax attr => Name(attr.Name),
-        IdentifierNameSyntax identifier => identifier.Identifier.Text,
-        InvocationExpressionSyntax invocation => Name(invocation.Expression),
-        MemberAccessExpressionSyntax memberAccess => Name(memberAccess.Name),
-        ParameterSyntax param => param.Identifier.Text,
-        SimpleNameSyntax simpleName => simpleName.Identifier.Text,
-        NameSyntax name => name.ToFullString(),
+        ArgumentSyntax n /*...............*/ => Name(n.Expression),
+        AttributeSyntax n /*..............*/ => Name(n.Name),
+        IdentifierNameSyntax n /*.........*/ => n.Identifier.Text,
+        InvocationExpressionSyntax n /*...*/ => Name(n.Expression),
+        MemberAccessExpressionSyntax n /*.*/ => Name(n.Name),
+        ParameterSyntax n /*..............*/ => n.Identifier.Text,
+        SimpleNameSyntax n /*.............*/ => n.Identifier.Text,
+        NameSyntax n /*...................*/ => n.ToFullString(),
+        PropertyDeclarationSyntax n /*....*/ => n.Identifier.Text,
         _ => null,
     };
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -26,73 +26,79 @@
     <PackageIconUrl>https://github.com/Qowaiv/qowaiv-analyzers/blob/main/design/package-icon.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <ToBeReleased>
+      <![CDATA[
+v2.0.5
+- QW0100: Define only one Required attribute (NEW RULE).
+      ]]>
+    </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
 v2.0.4
-- QWO0012: Exclude types form System.Collections.Frozen namespace (FP). #55
-- Generate SBOM. #54
+- QWO0012: Exclude types form System.Collections.Frozen namespace (FP).
+- Generate SBOM.
 v2.0.3
-- QW0017: Apply arithmetic operations on non-nullables only (NEW RULE). #51
+- QW0017: Apply arithmetic operations on non-nullables only (NEW RULE).
 v2.0.2
-- QW0011, QW0012: Improve messages. #50 
+- QW0011, QW0012: Improve messages.
 v2.0.1
-- QW0016: Only take public records into account (FP). #48
+- QW0016: Only take public records into account (FP).
 v2.0.0
-- Depend on Microsoft.CodeAnalysis 4.10.0 (potential breaking). #46
-- QW0016: Obsolete code and required by base parameters should be ignored (FP). #47
+- Depend on Microsoft.CodeAnalysis 4.10.0 (potential breaking).
+- QW0016: Obsolete code and required by base parameters should be ignored (FP).
 v1.0.9
-- QW0016: Locations are commonly past through as full paths (NEW RULE). #45
+- QW0016: Locations are commonly past through as full paths (NEW RULE).
 v1.0.8
-- QW0015: Locations are commonly past through as full paths (FP). #42
+- QW0015: Locations are commonly past through as full paths (FP).
 v1.0.7
-- QW0015: Define global using statements in single file (NEW RULE). #41
-- QW0014: Define global using statements separately (NEW RULE). #40
+- QW0015: Define global using statements in single file (NEW RULE).
+- QW0014: Define global using statements separately (NEW RULE).
 v1.0.6
-- QW0013: Use Qowaiv decimal rounding (NEW RULE). #39
-- QW0008: Take static read-only Empty properties into account (FN). #38
+- QW0013: Use Qowaiv decimal rounding (NEW RULE).
+- QW0008: Take static read-only Empty properties into account (FN).
 v1.0.5
-- QW0011, QW0012: Ingore IEnumerator and IXmlSerialable (FP). #37
+- QW0011, QW0012: Ingore IEnumerator and IXmlSerialable (FP).
 v1.0.4
-- QW0011, QW0012: Ignore types with a mutable base (FP). #36
+- QW0011, QW0012: Ignore types with a mutable base (FP).
 v1.0.3
-- QW0012: Types that have Immutable in there name are considered immutable (FP). #34
-- QW0003: [DoesNotReturn] should be valid alternative for [Pure] (FP). #33
+- QW0012: Types that have Immutable in there name are considered immutable (FP).
+- QW0003: [DoesNotReturn] should be valid alternative for [Pure] (FP).
 v1.0.2
-- QW0012: Reduce FP's by ignoring potential mutable property types (FP). #32
+- QW0012: Reduce FP's by ignoring potential mutable property types (FP).
 v1.0.1
-- QW0011: Define properties as immutables. #31
-- QW0012: Use immutable types for properties. #31
+- QW0011: Define properties as immutables.
+- QW0012: Use immutable types for properties.
 v1.0.0
-- QW0010: Use System.DateOnly instead of Qowaiv.Date. #29
-- CS0618, CS0619: Code fix for obsolete code with a suggestion. #30
-- Depend on Microsoft.CodeAnalysis 4.*. #27
+- QW0010: Use System.DateOnly instead of Qowaiv.Date.
+- CS0618, CS0619: Code fix for obsolete code with a suggestion.
+- Depend on Microsoft.CodeAnalysis 4.*.
 v0.0.8
-- Code fix for QW0005: Seal class. #26
-- FN: Generics containing types that should not be nullable are now taken into account. #25
+- Code fix for QW0005: Seal class.
+- FN: Generics containing types that should not be nullable are now taken into account.
 v0.0.7
-- Code fix for QW0008 and QW0009. #22
-- QW0009: Define properties as not-nullable for enums with a defined none value. #23
-- QW0008: Define properties as not-nullable for types with an empty state. #21
-- QW0008: Value Types with an empty state should be used as nullable properties. #18
+- Code fix for QW0008 and QW0009.
+- QW0009: Define properties as not-nullable for enums with a defined none value.
+- QW0008: Define properties as not-nullable for types with an empty state.
+- QW0008: Value Types with an empty state should be used as nullable properties.
 v0.0.6.1
-- QW0001: Provide a fix to suggest the usage of Qowaiv.Clock. #17
+- QW0001: Provide a fix to suggest the usage of Qowaiv.Clock.
 v0.0.6
-- QW0001: Also reports on DateTime.Offset. #17
+- QW0001: Also reports on DateTime.Offset.
 v0.0.5.3
-- QW0003: Returning ValueTask is never a pure function. #16
-- QW0003: Returning IDisposable can be a pure function. #16
+- QW0003: Returning ValueTask is never a pure function.
+- QW0003: Returning IDisposable can be a pure function.
 v0.0.5.2
-- QW0005: All attributes should be excluded. #15
+- QW0005: All attributes should be excluded.
 v0.0.5.1
-- QW0004: Mathematical Alphanumeric Symbols are not suspicious. #14
+- QW0004: Mathematical Alphanumeric Symbols are not suspicious.
 v0.0.5
-- QW0007: Use file-scoped namespace scopes. #13
+- QW0007: Use file-scoped namespace scopes.
 v0.0.4.1
-- QW0006: Seal concrete classes unless designed for inheritance. #9
+- QW0006: Seal concrete classes unless designed for inheritance.
 v0.0.4
-- QW0005: Seal concrete classes unless designed for inheritance. #9
+- QW0005: Seal concrete classes unless designed for inheritance.
 v0.0.3.1
-- QW0004: Horizontal tab (U+9, \t) is allowed too. #6
+- QW0004: Horizontal tab (U+9, \t) is allowed too.
 v0.0.3
 - QW0004: Characters with Trojan Horse potential are not allowed.
 v0.0.2

--- a/src/Qowaiv.CodeAnalysis.CSharp/README.md
+++ b/src/Qowaiv.CodeAnalysis.CSharp/README.md
@@ -19,6 +19,9 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) (s
 * [**QW0016** - Prefer regular over positional properties](rules/QW0016.md)
 * [**QW0017** - Apply arithmetic operations on non-nullables only](rules/QW0017.md)
 
+### Data Annotation rules
+* [**QW0100** - Define only one Required attribute](rules/QW0100.md)
+
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))
 * Seal class ([QW0005](rules/QW0005.md))

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -178,14 +178,14 @@ public static partial class Rule
             "outcome will be null if any of the arguments turns out to be null, " +
             "which can be confusing or a bug.",
         category: Category.Bug,
-        tags: ["nullabillity", "arithmetic"]);
+        tags: ["nullability", "arithmetic"]);
 
     public static DiagnosticDescriptor DefineOnlyOneRequiredAttribute => New(
         id: 0100,
         title: "Define only one Required attribute",
         message: "{0} should not be decorated with more than one required attribute",
         description:
-            "The compiler can not enforce single usages for overrriden implementations " +
+            "The compiler cannot enforce single usages for overridden implementations " +
             "of the [Required] attribute, but would otherwise disallow it.",
         category: Category.Bug,
         tags: ["Data Annotations", "AttributeUsage", "Validation", "RequiredAttribute"]);

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -170,13 +170,23 @@ public static partial class Rule
         tags: ["Design", "Maintainability"]);
 
     public static DiagnosticDescriptor ApplyArithmeticOperationsOnNonNullablesOnly => New(
-        id: 17,
+        id: 0017,
         title: "Apply arithmetic operations on non-nullables only",
         message: "{0} is potentially null.",
         description:
             ".NET allows arithmetic operations between nullable value types. The " +
             "outcome will be null if any of the arguments turns out to be null, " +
             "which can be confusing or a bug.",
+        category: Category.Bug,
+        tags: ["nullabillity", "arithmetic"]);
+
+    public static DiagnosticDescriptor DefineOnlyOneRequiredAttribute => New(
+        id: 0100,
+        title: "Define only one Required attribute",
+        message: "{0} should not be decorated with more than one required attribute",
+        description:
+            "The compiler can not enforce single usages for overrriden implementations " +
+            "of the [Required] attribute, but would otherwise disallow it.",
         category: Category.Bug,
         tags: ["nullabillity", "arithmetic"]);
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -188,7 +188,7 @@ public static partial class Rule
             "The compiler can not enforce single usages for overrriden implementations " +
             "of the [Required] attribute, but would otherwise disallow it.",
         category: Category.Bug,
-        tags: ["nullabillity", "arithmetic"]);
+        tags: ["Data Annotations", "AttributeUsage", "Validation", "RequiredAttribute"]);
 
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace Qowaiv.CodeAnalysis.Rules;
+namespace Qowaiv.CodeAnalysis.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DefineOnlyOneRequiredAttribute() : CodingRule(Rule.DefineOnlyOneRequiredAttribute)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
@@ -1,0 +1,26 @@
+﻿namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DefineOnlyOneRequiredAttribute() : CodingRule(Rule.DefineOnlyOneRequiredAttribute)
+{
+    protected override void Register(AnalysisContext context)
+        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.PropertyDeclaration);
+
+    private void Report(SyntaxNodeAnalysisContext context)
+    {
+        var property = context.Node.PropertyDeclaration(context.SemanticModel);
+
+        var found = 0;
+
+        foreach (var attribute in property.Attributes)
+        {
+            if (context.SemanticModel.GetSymbolInfo(attribute).Symbol is IMethodSymbol symbol
+                && symbol.ReceiverType is INamedTypeSymbol type
+                && type.IsAssignableTo(SystemType.System_ComponentModel_DataAnnotations_RequiredAttribute)
+                && ++found > 1)
+            {
+                context.ReportDiagnostic(Diagnostic, attribute, property.Name());
+            }
+        }
+    }
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
@@ -4,22 +4,26 @@
 public sealed class DefineOnlyOneRequiredAttribute() : CodingRule(Rule.DefineOnlyOneRequiredAttribute)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.PropertyDeclaration);
+        => context.RegisterSyntaxNodeAction(
+            Report,
+            SyntaxKind.PropertyDeclaration,
+            SyntaxKind.FieldDeclaration,
+            SyntaxKind.Parameter);
 
     private void Report(SyntaxNodeAnalysisContext context)
     {
-        var property = context.Node.PropertyDeclaration(context.SemanticModel);
+        var member = context.Node.MemberDeclaration(context.SemanticModel);
 
         var found = 0;
 
-        foreach (var attribute in property.Attributes)
+        foreach (var attribute in member.Attributes)
         {
             if (context.SemanticModel.GetSymbolInfo(attribute).Symbol is IMethodSymbol symbol
                 && symbol.ReceiverType is INamedTypeSymbol type
                 && type.IsAssignableTo(SystemType.System_ComponentModel_DataAnnotations_RequiredAttribute)
                 && ++found > 1)
             {
-                context.ReportDiagnostic(Diagnostic, attribute, property.Name());
+                context.ReportDiagnostic(Diagnostic, attribute, member.Name());
             }
         }
     }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Field.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Field.cs
@@ -1,0 +1,14 @@
+﻿namespace Qowaiv.CodeAnalysis.Syntax;
+
+public partial class MemberDeclaration
+{
+    internal sealed class Field(FieldDeclarationSyntax node, SemanticModel semanticModel) : MemberDeclaration(node, semanticModel)
+    {
+        private readonly FieldDeclarationSyntax TypedNode = node;
+
+        public override SyntaxList<AttributeListSyntax> AttributeLists => TypedNode.AttributeLists;
+
+        [Pure]
+        protected override ISymbol? GetSymbol(SemanticModel semanticModel) => semanticModel.GetDeclaredSymbol(TypedNode);
+    }
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Field.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Field.cs
@@ -1,4 +1,4 @@
-﻿namespace Qowaiv.CodeAnalysis.Syntax;
+namespace Qowaiv.CodeAnalysis.Syntax;
 
 public partial class MemberDeclaration
 {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Parameter.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Parameter.cs
@@ -1,0 +1,14 @@
+﻿namespace Qowaiv.CodeAnalysis.Syntax;
+
+public partial class MemberDeclaration
+{
+    internal sealed class Parameter(ParameterSyntax node, SemanticModel semanticModel) : MemberDeclaration(node, semanticModel)
+    {
+        private readonly ParameterSyntax TypedNode = node;
+
+        public override SyntaxList<AttributeListSyntax> AttributeLists => TypedNode.AttributeLists;
+
+        [Pure]
+        protected override ISymbol? GetSymbol(SemanticModel semanticModel) => semanticModel.GetDeclaredSymbol(TypedNode);
+    }
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Parameter.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Parameter.cs
@@ -1,4 +1,4 @@
-﻿namespace Qowaiv.CodeAnalysis.Syntax;
+namespace Qowaiv.CodeAnalysis.Syntax;
 
 public partial class MemberDeclaration
 {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Property.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Property.cs
@@ -1,0 +1,14 @@
+﻿namespace Qowaiv.CodeAnalysis.Syntax;
+
+public partial class MemberDeclaration
+{
+    internal sealed class Property(PropertyDeclarationSyntax node, SemanticModel semanticModel) : MemberDeclaration(node, semanticModel)
+    {
+        private readonly PropertyDeclarationSyntax TypedNode = node;
+
+        public override SyntaxList<AttributeListSyntax> AttributeLists => TypedNode.AttributeLists;
+
+        [Pure]
+        protected override ISymbol? GetSymbol(SemanticModel semanticModel) => semanticModel.GetDeclaredSymbol(TypedNode);
+    }
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Property.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Property.cs
@@ -1,4 +1,4 @@
-﻿namespace Qowaiv.CodeAnalysis.Syntax;
+namespace Qowaiv.CodeAnalysis.Syntax;
 
 public partial class MemberDeclaration
 {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.cs
@@ -1,0 +1,13 @@
+﻿namespace Qowaiv.CodeAnalysis.Syntax;
+
+public abstract partial class MemberDeclaration : SyntaxAbstraction<ISymbol>
+{
+    protected MemberDeclaration(SyntaxNode node, SemanticModel semanticModel)
+        : base(node, semanticModel)
+    {
+    }
+
+    public abstract SyntaxList<AttributeListSyntax> AttributeLists { get; }
+
+    public IEnumerable<AttributeSyntax> Attributes => AttributeLists.SelectMany(a => a.Attributes);
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.cs
@@ -1,4 +1,4 @@
-﻿namespace Qowaiv.CodeAnalysis.Syntax;
+namespace Qowaiv.CodeAnalysis.Syntax;
 
 public abstract partial class MemberDeclaration : SyntaxAbstraction<ISymbol>
 {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/PropertyDeclaration.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/PropertyDeclaration.cs
@@ -27,6 +27,8 @@ public sealed class PropertyDeclaration : SyntaxAbstraction<IPropertySymbol>
     public IEnumerable<SyntaxKind> Accessors
         => TypedNode.AccessorList?.Accessors.Select(s => s.Kind()) ?? [];
 
+    public IEnumerable<AttributeSyntax> Attributes => TypedNode.AttributeLists.SelectMany(a => a.Attributes);
+
     public bool IsObsolete
         => Symbol is { } symbol
         && symbol.IsObsolete();

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -19,6 +19,8 @@ public partial class SystemType
     public static readonly SystemType System_Collections_Generic_IReadOnlyList_T = new("System.Collections.Generic.IReadOnlyList<T>");
     public static readonly SystemType System_Collections_Generic_IReadOnlySet_T = new("System.Collections.Generic.IReadOnlySet<T>");
 
+    public static readonly SystemType System_ComponentModel_DataAnnotations_RequiredAttribute = new("System.ComponentModel.DataAnnotations.RequiredAttribute");
+
     public static readonly SystemType System_Attribute = typeof(System.Attribute);
     public static readonly SystemType System_DateOnly = new("System.DateOnly");
     public static readonly SystemType System_DateTimeOffset = typeof(System.DateTimeOffset);


### PR DESCRIPTION
The `[Required]` attribute is designed to be used in isolation. It usage is defined as follows:

``` C#
[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
```

The reasoning for this is, that if the required constraint is not met, no further validation is done. When `[Required]` is overridden (by `[Any]`, `[Mandatory]`,  `[Optional]`, or whatever which implementation) this constraint should still apply but the compiler will not longer enforce this, hence this rule.

## Non-compliant
``` C#
class Model
{
    [Any]
    [Required]
    public int[] Numbers { get; init; }
}
```

## Compliant
``` C#
class Model
{
    [Any]
    public int[] Numbers { get; init; }
}
````
