### PR TITLE
QW0101: Required attribute cannot invalidate value types

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 
 ### Data Annotation rules
 * [**QW0100** - Define only one Required attribute](rules/QW0100.md)
+* [**QW0101** - Required attribute cannot invalidate value types](rules/QW0101.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))

--- a/rules/QW0101.md
+++ b/rules/QW0101.md
@@ -14,11 +14,11 @@ class Model
 ```
 
 ## Compliant
-If the default value was is not allowed:
+If the default value is not allowed:
 ``` C#
 class Model
 {
-    [Qowaiv.Valdation.DataAnnotations.Mandatory]
+    [Qowaiv.Validation.DataAnnotations.Mandatory]
     public int Number { get; init; }
 }
 ````

--- a/rules/QW0101.md
+++ b/rules/QW0101.md
@@ -1,0 +1,41 @@
+# QW0101: Required attribute cannot invalidate value types
+
+The `[Required]` attribute checks if the value is null. This is always true
+for value types except for `Nullable<T>`. The use of the `[Required]` attribute
+is most likely not doing what might be expected, and should be prevented.
+
+## Non-compliant
+``` C#
+class Model
+{
+    [Required]
+    public int Number { get; init; }
+}
+```
+
+## Compliant
+If the default value was is not allowed:
+``` C#
+class Model
+{
+    [Qowaiv.Valdation.DataAnnotations.Mandatory]
+    public int Number { get; init; }
+}
+````
+
+If not set should be able possible (but is invalid):
+``` C#
+class Model
+{
+    [Required]
+    public int? Number { get; init; }
+}
+````
+
+If it must only be assured that the value is set in code.
+``` C#
+class Model
+{
+    public required int Number { get; init; }
+}
+````

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/RequiredAttributeCannotInvalidateValueTypes.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/RequiredAttributeCannotInvalidateValueTypes.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+
+class OnProperties
+{
+    [Required] // Compliant
+    public string NonValueType { get; init; }
+
+    [Optional] // Compliant
+    public int DerivedRequired { get; init; }
+
+    [Required] // Compliant
+    public int? Nullable { get; init; }
+
+    [Required] // Noncompliant {{The value of this value type will always meet the Required constraints}}
+//   ^^^^^^^^     
+    public int Integer { get; init; }
+
+    [Required] // Noncompliant
+    public System.Guid Guid { get; init; }
+
+    [Required] // Noncompliant
+    public MyEnum Enum { get; init; }
+}
+
+class OnFields
+{
+    [Required] // Noncompliant
+    public int ValueType;
+}
+
+record OnRecords([Required] int ValueType, [Required] string WithSingle); // Noncompliant
+//                ^^^^^^^^
+
+public enum MyEnum { }
+
+public sealed class OptionalAttribute : RequiredAttribute { }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Required_attribute_cannot_invalidate_value_types.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Required_attribute_cannot_invalidate_value_types.cs
@@ -1,0 +1,11 @@
+namespace Rules.Required_attribute_cannot_invalidate_value_types;
+
+public class Verify
+{
+    [Test]
+    public void Required_properties() => new RequiredAttributeCannotInvalidateValueTypes()
+        .ForCS()
+        .AddSource(@"Cases/RequiredAttributeCannotInvalidateValueTypes.cs")
+        .AddReference<System.ComponentModel.DataAnnotations.RequiredAttribute>()
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
@@ -36,6 +36,11 @@ internal static class SymbolExtensions
         => type.IsAssignableTo(SystemType.System_Exception);
 
     [Pure]
+    public static bool IsNotNullableValueType(this ITypeSymbol type)
+        => type.IsValueType
+        && type is not { SpecialType: SpecialType.System_Nullable_T } and not { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T };
+
+    [Pure]
     public static bool IsNullableValueType(this ITypeSymbol type)
         => type.IsValueType
         && type is { SpecialType: SpecialType.System_Nullable_T } or { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T };

--- a/src/Qowaiv.CodeAnalysis.CSharp/README.md
+++ b/src/Qowaiv.CodeAnalysis.CSharp/README.md
@@ -21,6 +21,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) (s
 
 ### Data Annotation rules
 * [**QW0100** - Define only one Required attribute](rules/QW0100.md)
+* [**QW0101** - Required attribute cannot invalidate value types](rules/QW0101.md)
 
 ## Code fixes
 * Use Qowaiv.Clock ([QW0001](rules/QW0001.md), [S6354](https://rules.sonarsource.com/csharp/RSPEC-6354))

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -195,8 +195,8 @@ public static partial class Rule
         title: "Required attribute cannot invalidate value types",
         message: "The value of this value type will always meet the Required constraints",
         description:
-            "The implementation of the Required attribute it to check if the " +
-            "value is not null This is always true for non-nullable value types.",
+            "The implementation of the Required attribute is to check if the " +
+            "value is not null. This is always true for non-nullable value types.",
         category: Category.Bug,
         tags: ["Data Annotations", "Validation", "RequiredAttribute"]);
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -190,6 +190,16 @@ public static partial class Rule
         category: Category.Bug,
         tags: ["Data Annotations", "AttributeUsage", "Validation", "RequiredAttribute"]);
 
+    public static DiagnosticDescriptor RequiredCannotInvalidateValueTypes => New(
+        id: 0101,
+        title: "Required attribute cannot invalidate value types",
+        message: "The value of this value type will always meet the Required constraints",
+        description:
+            "The implementation of the Required attribute it to check if the " +
+            "value is not null This is always true for non-nullable value types.",
+        category: Category.Bug,
+        tags: ["Data Annotations", "Validation", "RequiredAttribute"]);
+
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
     private static DiagnosticDescriptor New(

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
@@ -18,8 +18,7 @@ public sealed class DefineOnlyOneRequiredAttribute() : CodingRule(Rule.DefineOnl
 
         foreach (var attribute in member.Attributes)
         {
-            if (context.SemanticModel.GetSymbolInfo(attribute).Symbol is IMethodSymbol symbol
-                && symbol.ReceiverType is INamedTypeSymbol type
+            if (attribute.Symbol is { } type
                 && type.IsAssignableTo(SystemType.System_ComponentModel_DataAnnotations_RequiredAttribute)
                 && ++found > 1)
             {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
@@ -1,0 +1,29 @@
+namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RequiredAttributeCannotInvalidateValueTypes() : CodingRule(Rule.RequiredCannotInvalidateValueTypes)
+{
+    protected override void Register(AnalysisContext context)
+     => context.RegisterSyntaxNodeAction(
+            Report,
+            SyntaxKind.PropertyDeclaration,
+            SyntaxKind.FieldDeclaration,
+            SyntaxKind.Parameter);
+
+    private void Report(SyntaxNodeAnalysisContext context)
+    {
+        var member = context.Node.MemberDeclaration(context.SemanticModel);
+
+        if (member.Attributes.Any() && member.Symbol is { } symbol && symbol.IsNotNullableValueType())
+        {
+            foreach (var attribute in member.Attributes)
+            {
+                if (attribute.Symbol is { } type
+                    && type.Is(SystemType.System_ComponentModel_DataAnnotations_RequiredAttribute))
+                {
+                    context.ReportDiagnostic(Diagnostic, attribute);
+                }
+            }
+        }
+    }
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/AttributeDecoration.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/AttributeDecoration.cs
@@ -1,0 +1,11 @@
+namespace Qowaiv.CodeAnalysis.Syntax;
+
+public sealed class AttributeDecoration(AttributeSyntax node, SemanticModel semanticModel) : SyntaxAbstraction<ITypeSymbol>(node, semanticModel)
+{
+    private readonly AttributeSyntax TypedNode = node;
+
+    protected override ITypeSymbol? GetSymbol(SemanticModel semanticModel)
+        => semanticModel.GetSymbolInfo(TypedNode).Symbol is IMethodSymbol symbol
+        ? symbol.ReceiverType as INamedTypeSymbol
+        : null;
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Field.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Field.cs
@@ -9,6 +9,7 @@ public partial class MemberDeclaration
         public override SyntaxList<AttributeListSyntax> AttributeLists => TypedNode.AttributeLists;
 
         [Pure]
-        protected override ISymbol? GetSymbol(SemanticModel semanticModel) => semanticModel.GetDeclaredSymbol(TypedNode);
+        protected override ITypeSymbol? GetSymbol(SemanticModel semanticModel)
+            => semanticModel.GetTypeInfo(TypedNode.Declaration.Type).Type;
     }
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Parameter.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Parameter.cs
@@ -9,6 +9,9 @@ public partial class MemberDeclaration
         public override SyntaxList<AttributeListSyntax> AttributeLists => TypedNode.AttributeLists;
 
         [Pure]
-        protected override ISymbol? GetSymbol(SemanticModel semanticModel) => semanticModel.GetDeclaredSymbol(TypedNode);
+        protected override ITypeSymbol? GetSymbol(SemanticModel semanticModel)
+            => semanticModel.GetDeclaredSymbol(TypedNode) is IParameterSymbol symbol
+                ? symbol.Type
+                : null;
     }
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Property.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Property.cs
@@ -9,6 +9,9 @@ public partial class MemberDeclaration
         public override SyntaxList<AttributeListSyntax> AttributeLists => TypedNode.AttributeLists;
 
         [Pure]
-        protected override ISymbol? GetSymbol(SemanticModel semanticModel) => semanticModel.GetDeclaredSymbol(TypedNode);
+        protected override ITypeSymbol? GetSymbol(SemanticModel semanticModel)
+            => semanticModel.GetDeclaredSymbol(TypedNode) is IPropertySymbol property
+                ? property.Type
+                : null;
     }
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.cs
@@ -1,6 +1,6 @@
 namespace Qowaiv.CodeAnalysis.Syntax;
 
-public abstract partial class MemberDeclaration : SyntaxAbstraction<ISymbol>
+public abstract partial class MemberDeclaration : SyntaxAbstraction<ITypeSymbol>
 {
     protected MemberDeclaration(SyntaxNode node, SemanticModel semanticModel)
         : base(node, semanticModel)
@@ -9,5 +9,7 @@ public abstract partial class MemberDeclaration : SyntaxAbstraction<ISymbol>
 
     public abstract SyntaxList<AttributeListSyntax> AttributeLists { get; }
 
-    public IEnumerable<AttributeSyntax> Attributes => AttributeLists.SelectMany(a => a.Attributes);
+    public IEnumerable<AttributeDecoration> Attributes => AttributeLists
+        .SelectMany(a => a.Attributes)
+        .Select(a => new AttributeDecoration(a, SemanticModel));
 }


### PR DESCRIPTION
The `[Required]` attribute checks if the value is null. This is always true for value types except for `Nullable<T>`. The use of the `[Required]` attribute is most likely not doing what might be expected, and should be prevented.

## Non-compliant
``` C#
class Model
{
    [Required]
    public int Number { get; init; }
}
```

## Compliant
If the default value was is not allowed:
``` C#
class Model
{
    [Qowaiv.Valdation.DataAnnotations.Mandatory]
    public int Number { get; init; }
}
````

If not set should be able possible (but is invalid):
``` C#
class Model
{
    [Required]
    public int? Number { get; init; }
}
````

If it must only be assured that the value is set in code.
``` C#
class Model
{
    public required int Number { get; init; }
}
````
