### PR TITLE
QW0102: Use compliant validation attributes

### DIFF
--- a/rules/QW0101.md
+++ b/rules/QW0101.md
@@ -21,7 +21,7 @@ class Model
     [Qowaiv.Validation.DataAnnotations.Mandatory]
     public int Number { get; init; }
 }
-````
+```
 
 If not set should be able possible (but is invalid):
 ``` C#
@@ -30,7 +30,7 @@ class Model
     [Required]
     public int? Number { get; init; }
 }
-````
+```
 
 If it must only be assured that the value is set in code.
 ``` C#
@@ -38,4 +38,4 @@ class Model
 {
     public required int Number { get; init; }
 }
-````
+```

--- a/rules/QW0102.md
+++ b/rules/QW0102.md
@@ -1,0 +1,27 @@
+# QW0102: Use compliant validation attributes
+
+Validation attributes are designed to validate certain member types. When
+applied on other types, this is invalid, and might even crash.
+
+Which types are supported by a validator can be defined by decorating a
+validator either with `[Valdates(typeof(ValidatedType))]` or
+`[Validates(GenericArgument = true)]` when is assumed that the the
+generic argument of the attribute is equal to the that is suppored.
+
+## Non-compliant
+``` C#
+class Model
+{
+    [Allowed<int>(42, 2017)]
+    public string Number { get; init; }
+}
+```
+
+## Compliant
+``` C#
+class Model
+{
+    [Allowed<string>("42", "2017")]
+    public string Number { get; init; }
+}
+```

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.BuildIn.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.BuildIn.cs
@@ -1,0 +1,76 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+class Noncompliant
+{
+    [AllowedValues(42)] // Noncompliant
+    public Guid AllowedValues { get; init; }
+
+    [Base64String] // Noncompliant
+    public long Base64String { get; init; }
+
+    [CreditCard] // Noncompliant
+    public int CreditCard { get; init; }
+
+    [DeniedValues(1983)] // Noncompliant
+    public int DeniedValues { get; init; }
+
+    [EmailAddress] // Noncompliant
+    public int EmailAddress { get; init; }
+
+    [EnumDataType(typeof(int))] // Noncompliant
+    public int EnumDataType { get; init; }
+
+    [FileExtensions] // Noncompliant
+    public int FileExtensions { get; init; }
+
+    [Phone] // Noncompliant
+    public int Phone { get; init; }
+
+    [Range(3, 4)] // Noncompliant
+    public object Range { get; init; }
+
+    [StringLength(3)] // Noncompliant
+    public Guid StringLength { get; init; }
+
+    [Url] // Noncompliant
+    public Guid Url { get; init; }
+}
+
+class Compliant
+{
+    [AllowedValues(43)]
+    public int AllowedValues { get; init; }
+
+    [Base64String]
+    public string Base64String { get; init; }
+
+    [CreditCard] 
+    public string CreditCard { get; init; }
+
+    [DeniedValues(1983)] 
+    public string DeniedValues { get; init; }
+
+    [EmailAddress]
+    public int EmailAddress { get; init; }
+
+    [EnumDataType(typeof(MyEnum))]
+    public MyEnum EnumDataType { get; init; }
+
+    [FileExtensions]
+    public string FileExtensions { get; init; }
+
+    [Phone]
+    public string Phone { get; init; }
+
+    [Range(3, 4)]
+    public int Range { get; init; }
+
+    [StringLength(3)]
+    public string StringLength { get; init; }
+
+    [Url]
+    public string Url { get; init; }
+}
+
+public enum MyEnum { }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.cs
@@ -24,13 +24,19 @@ class Compliant
     public int? Nullability { get; init; }
 
     [Number] // Compliant
-    public long AnyOfAllowed { get; init; }
+    public int AnyOfAllowed1 { get; init; }
+
+    [Number] // Compliant
+    public long AnyOfAllowed2 { get; init; }
 
     [Display(Name = "No validation")]
     public Guid NoValidation { get; init; }
 
     [Generic<string>] // Compliant
     public string Generic { get; init; }
+
+    [Optional] // Compliant
+    public bool? NotDecoratedValidationAttribute { get; init; }
 }
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
@@ -42,6 +48,8 @@ sealed class ValidatesAttribute : Attribute
 
     public bool GenericArgument { get; init; }
 }
+
+sealed class OptionalAttribute : ValidationAttribute { }
 
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
 [Validates(GenericArgument = true)]

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using Qowaiv.Validation.DataAnnotations;
 
 class Noncompliant
 {
@@ -41,11 +42,17 @@ class Compliant
     [Optional] // Compliant
     public bool? NotDecoratedValidationAttribute { get; init; }
 
-    [TypeByString]
+    [TypeByString] // Compliant
     public Guid TypeByString { get; init; }
+
+    [Undecorated] // Compliant
+    public int Undecorated { get; init; }
 }
 
+[Validates(typeof(object))]
 sealed class OptionalAttribute : ValidationAttribute { }
+
+sealed class UndecoratedAttribute : ValidationAttribute { }
 
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
 [Validates(GenericArgument = true)]
@@ -62,26 +69,27 @@ sealed class NumberAttribute : ValidationAttribute { }
 sealed class TypeByStringAttribute : ValidationAttribute { }
 
 
-//namespace Qowaiv.Validation.DataAnnotations;
-
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-public sealed class ValidatesAttribute : Attribute
+namespace Qowaiv.Validation.DataAnnotations
 {
-    /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
-    public ValidatesAttribute() : this(typeof(object)) { }
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public sealed class ValidatesAttribute : Attribute
+    {
+        /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
+        public ValidatesAttribute() : this(typeof(object)) { }
 
-    /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
-    public ValidatesAttribute(string typeName) => Type = Type.GetType(typeName) ?? typeof(object);
+        /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
+        public ValidatesAttribute(string typeName) => Type = Type.GetType(typeName) ?? typeof(object);
 
-    /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
-    public ValidatesAttribute(Type type) => Type = type;
+        /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
+        public ValidatesAttribute(Type type) => Type = type;
 
-    /// <summary>Type that can be validated.</summary>
-    public Type Type { get; }
+        /// <summary>Type that can be validated.</summary>
+        public Type Type { get; }
 
-    /// <summary>
-    /// If true, the type should be equal to the generic to the generic
-    /// argument of the <see cref="ValidationAttribute"/>.
-    /// </summary>
-    public bool GenericArgument { get; init; }
+        /// <summary>
+        /// If true, the type should be equal to the generic to the generic
+        /// argument of the <see cref="ValidationAttribute"/>.
+        /// </summary>
+        public bool GenericArgument { get; init; }
+    }
 }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+class Noncompliant
+{
+    [IntOnly] // Noncompliant {{The attribute cannot validate this type}}
+//   ^^^^^^^
+    public string String { get; init; }
+
+    [Number] // Noncompliant
+    public string NoneOfAllowed { get; init; }
+
+    [Generic<Guid>] // Noncompliant
+    [Generic<string>]
+    public string Generic { get; init; }
+}
+
+class Compliant
+{
+    [IntOnly] // Compliant
+    public int Int32 { get; init; }
+
+    [IntOnly] // Compliant
+    public int? Nullability { get; init; }
+
+    [Number] // Compliant
+    public long AnyOfAllowed { get; init; }
+
+    [Display(Name = "No validation")]
+    public Guid NoValidation { get; init; }
+
+    [Generic<string>] // Compliant
+    public string Generic { get; init; }
+}
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+sealed class ValidatesAttribute : Attribute 
+{
+    public ValidatesAttribute(Type type) { }
+
+    public ValidatesAttribute() { }
+
+    public bool GenericArgument { get; init; }
+}
+
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+[Validates(GenericArgument = true)]
+sealed class GenericAttribute<T> : ValidationAttribute { }
+
+[Validates(typeof(int))]
+sealed class IntOnlyAttribute : ValidationAttribute { }
+
+[Validates(typeof(int))]
+[Validates(typeof(long))]
+sealed class NumberAttribute : ValidationAttribute { }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/UseCompliantValdationAttribute.cs
@@ -13,6 +13,9 @@ class Noncompliant
     [Generic<Guid>] // Noncompliant
     [Generic<string>]
     public string Generic { get; init; }
+
+    [TypeByString] // Noncompliant
+    public string TypeByString { get; init; }
 }
 
 class Compliant
@@ -37,16 +40,9 @@ class Compliant
 
     [Optional] // Compliant
     public bool? NotDecoratedValidationAttribute { get; init; }
-}
 
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-sealed class ValidatesAttribute : Attribute 
-{
-    public ValidatesAttribute(Type type) { }
-
-    public ValidatesAttribute() { }
-
-    public bool GenericArgument { get; init; }
+    [TypeByString]
+    public Guid TypeByString { get; init; }
 }
 
 sealed class OptionalAttribute : ValidationAttribute { }
@@ -61,3 +57,31 @@ sealed class IntOnlyAttribute : ValidationAttribute { }
 [Validates(typeof(int))]
 [Validates(typeof(long))]
 sealed class NumberAttribute : ValidationAttribute { }
+
+[Validates("System.Guid")]
+sealed class TypeByStringAttribute : ValidationAttribute { }
+
+
+//namespace Qowaiv.Validation.DataAnnotations;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class ValidatesAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
+    public ValidatesAttribute() : this(typeof(object)) { }
+
+    /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
+    public ValidatesAttribute(string typeName) => Type = Type.GetType(typeName) ?? typeof(object);
+
+    /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
+    public ValidatesAttribute(Type type) => Type = type;
+
+    /// <summary>Type that can be validated.</summary>
+    public Type Type { get; }
+
+    /// <summary>
+    /// If true, the type should be equal to the generic to the generic
+    /// argument of the <see cref="ValidationAttribute"/>.
+    /// </summary>
+    public bool GenericArgument { get; init; }
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_compliant_valdation_attribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_compliant_valdation_attribute.cs
@@ -8,4 +8,11 @@ public class Verify
         .AddSource(@"Cases/UseCompliantValdationAttribute.cs")
         .AddReference<System.ComponentModel.DataAnnotations.ValidationAttribute>()
         .Verify();
+
+    [Test]
+    public void compliance_of_build_in_validation_attributes() => new UseCompliantValdationAttribute()
+        .ForCS()
+        .AddSource(@"Cases/UseCompliantValdationAttribute.BuildIn.cs")
+        .AddReference<System.ComponentModel.DataAnnotations.ValidationAttribute>()
+        .Verify();
 }

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_compliant_valdation_attribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_compliant_valdation_attribute.cs
@@ -9,7 +9,7 @@ public class Verify
         .AddReference<System.ComponentModel.DataAnnotations.ValidationAttribute>()
         .Verify();
 
-    [Test]
+    [Test, Ignore("Do in a follow up")]
     public void compliance_of_build_in_validation_attributes() => new UseCompliantValdationAttribute()
         .ForCS()
         .AddSource(@"Cases/UseCompliantValdationAttribute.BuildIn.cs")

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_compliant_valdation_attribute.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Use_compliant_valdation_attribute.cs
@@ -1,0 +1,11 @@
+namespace Rules.Use_compliant_valdation_attribute;
+
+public class Verify
+{
+    [Test]
+    public void compliance_of_validation_attributes() => new UseCompliantValdationAttribute()
+        .ForCS()
+        .AddSource(@"Cases/UseCompliantValdationAttribute.cs")
+        .AddReference<System.ComponentModel.DataAnnotations.ValidationAttribute>()
+        .Verify();
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
@@ -19,6 +19,11 @@ internal static class SymbolExtensions
         => Array.Exists(types, symbol.Is);
 
     [Pure]
+    public static bool IsAssignableTo(this ITypeSymbol? symbol, ITypeSymbol type)
+       => SymbolEqualityComparer.IncludeNullability.Equals(symbol , type)
+       || (symbol?.BaseType is { } @base && @base.IsAssignableTo(type));
+
+    [Pure]
     public static bool IsAssignableTo(this ITypeSymbol? symbol, SystemType type)
         => (symbol is { } && symbol.IsMatch(type))
         || (symbol?.BaseType is { } @base && @base.IsAssignableTo(type));

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/System.Linq.Enumerable.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/System.Linq.Enumerable.cs
@@ -2,6 +2,10 @@ namespace System.Linq;
 
 internal static class EnumerableExtensions
 {
+    [Pure]
+    public static bool None<T>(this IEnumerable<T> enumerable, Func<T, bool> predicate)
+        => !enumerable.Any(predicate);
+
     public static IReadOnlyList<T> Singleton<T>(this T? item)
         => item is { } ? [item] : Array.Empty<T>();
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -1,6 +1,8 @@
 #pragma warning disable SA1118 // Parameter should not span multiple lines.
 // For readability, here it is preferred.
 
+using static Qowaiv.CodeAnalysis.Syntax.TypeDeclaration;
+
 namespace Qowaiv.CodeAnalysis;
 
 public static partial class Rule
@@ -199,6 +201,16 @@ public static partial class Rule
             "value is not null. This is always true for non-nullable value types.",
         category: Category.Bug,
         tags: ["Data Annotations", "Validation", "RequiredAttribute"]);
+
+    public static DiagnosticDescriptor UseCompliantValdationAttribute => New(
+        id: 0102,
+        title: "Use compliant validation attributes",
+        message: "The attribute cannot validate this type",
+        description:
+            "Validation attributes are designed to validate certain member types. " +
+            "When applied on other types, this is invalid, and might even crash.",
+        category: Category.Bug,
+        tags: ["Data Annotations", "Validation", "ValidationAttribute"]);
 
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseCompliantValdationAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseCompliantValdationAttribute.cs
@@ -1,0 +1,70 @@
+using System.Collections.Concurrent;
+
+namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseCompliantValdationAttribute() : CodingRule(Rule.UseCompliantValdationAttribute)
+{
+    protected override void Register(AnalysisContext context)
+        => context.RegisterSyntaxNodeAction(
+            Report,
+            SyntaxKind.PropertyDeclaration,
+            SyntaxKind.FieldDeclaration,
+            SyntaxKind.Parameter);
+
+    private void Report(SyntaxNodeAnalysisContext context)
+    {
+        var member = context.Node.MemberDeclaration(context.SemanticModel);
+
+        if (member.Attributes.Any() && member.Symbol is { } mSymbol)
+        {
+            mSymbol = mSymbol.NotNullable() ?? mSymbol;
+
+            foreach (var attribute in member.Attributes.Where(a => !CanValidate(mSymbol, a.Symbol)))
+            {
+                context.ReportDiagnostic(Diagnostic, attribute);
+            }
+        }
+    }
+
+    private static bool CanValidate(INamedTypeSymbol member, INamedTypeSymbol? attribute)
+    {
+        if (attribute is null
+            || !attribute.IsAssignableTo(SystemType.System_ComponentModel_DataAnnotations_ValidationAttribute))
+        {
+            return true;
+        }
+
+        if (!Lookup.TryGetValue(attribute, out var data))
+        {
+            data = Validates(attribute);
+            Lookup[attribute] = data;
+        }
+
+        return data is { Length: 0 } || data.Any(member.IsAssignableTo);
+    }
+
+    private static ITypeSymbol[] Validates(INamedTypeSymbol attribute) => [..attribute
+        .GetAttributes()
+        .Where(data => data.AttributeClass?.Name.Matches("ValidatesAttribute") is true)
+        .Select(data => GetType(data) ?? GetGeneric(data, attribute))
+        .OfType<ITypeSymbol>()];
+
+    private static ITypeSymbol? GetType(AttributeData data)
+        => data.ConstructorArguments is { Length: 1 } args
+        && args[0].Value is ITypeSymbol validates
+        ? validates
+        : null;
+
+    private static ITypeSymbol? GetGeneric(AttributeData data, INamedTypeSymbol attribute)
+        => attribute.IsGenericType
+        && data.NamedArguments.FirstOrDefault(kvp => kvp.Key == "GenericArgument").Value.Value is true
+        ? attribute.TypeArguments[0]
+        : null;
+
+#pragma warning disable RS1008 
+    // Avoid storing per-compilation data into the fields of a diagnostic analyzer
+    // We do this to cache the annoatations on Validation Attributes. This reduces
+    // The analysis times.
+    private static readonly ConcurrentDictionary<ITypeSymbol, ITypeSymbol[]> Lookup = [];
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseCompliantValdationAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseCompliantValdationAttribute.cs
@@ -38,7 +38,8 @@ public sealed class UseCompliantValdationAttribute() : CodingRule(Rule.UseCompli
         if (!Lookup.TryGetValue(attribute, out var data))
         {
             data = Validates(attribute);
-            Lookup[attribute] = data;
+            // If it contains data, its matches everyting.
+            Lookup[attribute] = data.Contains(SystemType.System.Object) ? [] : data;
         }
 
         return data is { Length: 0 } || data.Any(member.IsAssignableTo);
@@ -46,8 +47,8 @@ public sealed class UseCompliantValdationAttribute() : CodingRule(Rule.UseCompli
 
     private static SystemType[] Validates(INamedTypeSymbol attribute) => [..attribute
         .GetAttributes()
-        .Where(data => data.AttributeClass?.Name.Matches("ValidatesAttribute") is true)
-        .Select(data => GetType(data) ?? GetGeneric(data, attribute))
+        .Where(data => data.AttributeClass.Is(SystemType.Qowaiv.Validation.DataAnnotations.ValidatesAttribute))
+        .Select(data => GetType(data) ?? GetStringType(data) ?? GetGeneric(data, attribute))
         .OfType<SystemType>()];
 
     private static SystemType? GetType(AttributeData data)
@@ -72,5 +73,5 @@ public sealed class UseCompliantValdationAttribute() : CodingRule(Rule.UseCompli
     // Avoid storing per-compilation data into the fields of a diagnostic analyzer
     // We do this to cache the annoatations on Validation Attributes. This reduces
     // The analysis times.
-    private static readonly ConcurrentDictionary<ITypeSymbol, SystemType[]> Lookup = [];
+    private static readonly ConcurrentDictionary<INamedTypeSymbol, SystemType[]> Lookup = [];
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseCompliantValdationAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseCompliantValdationAttribute.cs
@@ -30,7 +30,7 @@ public sealed class UseCompliantValdationAttribute() : CodingRule(Rule.UseCompli
     private static bool CanValidate(INamedTypeSymbol member, INamedTypeSymbol? attribute)
     {
         if (attribute is null
-            || !attribute.IsAssignableTo(SystemType.System_ComponentModel_DataAnnotations_ValidationAttribute))
+            || !attribute.IsAssignableTo(SystemType.System.ComponentModel.DataAnnotations.ValidationAttribute))
         {
             return true;
         }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/AttributeDecoration.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/AttributeDecoration.cs
@@ -1,10 +1,10 @@
 namespace Qowaiv.CodeAnalysis.Syntax;
 
-public sealed class AttributeDecoration(AttributeSyntax node, SemanticModel semanticModel) : SyntaxAbstraction<ITypeSymbol>(node, semanticModel)
+public sealed class AttributeDecoration(AttributeSyntax node, SemanticModel semanticModel) : SyntaxAbstraction<INamedTypeSymbol>(node, semanticModel)
 {
     private readonly AttributeSyntax TypedNode = node;
 
-    protected override ITypeSymbol? GetSymbol(SemanticModel semanticModel)
+    protected override INamedTypeSymbol? GetSymbol(SemanticModel semanticModel)
         => semanticModel.GetSymbolInfo(TypedNode).Symbol is IMethodSymbol symbol
         ? symbol.ReceiverType as INamedTypeSymbol
         : null;

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Field.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Field.cs
@@ -9,7 +9,7 @@ public partial class MemberDeclaration
         public override SyntaxList<AttributeListSyntax> AttributeLists => TypedNode.AttributeLists;
 
         [Pure]
-        protected override ITypeSymbol? GetSymbol(SemanticModel semanticModel)
-            => semanticModel.GetTypeInfo(TypedNode.Declaration.Type).Type;
+        protected override INamedTypeSymbol? GetSymbol(SemanticModel semanticModel)
+            => semanticModel.GetTypeInfo(TypedNode.Declaration.Type).Type as INamedTypeSymbol;
     }
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Parameter.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Parameter.cs
@@ -9,9 +9,9 @@ public partial class MemberDeclaration
         public override SyntaxList<AttributeListSyntax> AttributeLists => TypedNode.AttributeLists;
 
         [Pure]
-        protected override ITypeSymbol? GetSymbol(SemanticModel semanticModel)
+        protected override INamedTypeSymbol? GetSymbol(SemanticModel semanticModel)
             => semanticModel.GetDeclaredSymbol(TypedNode) is IParameterSymbol symbol
-                ? symbol.Type
+                ? symbol.Type as INamedTypeSymbol
                 : null;
     }
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Property.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.Property.cs
@@ -9,9 +9,9 @@ public partial class MemberDeclaration
         public override SyntaxList<AttributeListSyntax> AttributeLists => TypedNode.AttributeLists;
 
         [Pure]
-        protected override ITypeSymbol? GetSymbol(SemanticModel semanticModel)
+        protected override INamedTypeSymbol? GetSymbol(SemanticModel semanticModel)
             => semanticModel.GetDeclaredSymbol(TypedNode) is IPropertySymbol property
-                ? property.Type
+                ? property.Type as INamedTypeSymbol
                 : null;
     }
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Syntax/MemberDeclaration.cs
@@ -1,6 +1,6 @@
 namespace Qowaiv.CodeAnalysis.Syntax;
 
-public abstract partial class MemberDeclaration : SyntaxAbstraction<ITypeSymbol>
+public abstract partial class MemberDeclaration : SyntaxAbstraction<INamedTypeSymbol>
 {
     protected MemberDeclaration(SyntaxNode node, SemanticModel semanticModel)
         : base(node, semanticModel)

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -41,6 +41,7 @@ public partial class SystemType
         {
             public static class DataAnnotations
             {
+                public static readonly SystemType AllowedValuesAttribute = new("System.ComponentModel.DataAnnotations.AllowedValuesAttribute");
                 public static readonly SystemType RequiredAttribute = new("System.ComponentModel.DataAnnotations.RequiredAttribute");
                 public static readonly SystemType ValidationAttribute = new("System.ComponentModel.DataAnnotations.ValidationAttribute");
             }

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -37,6 +37,15 @@ public partial class SystemType
             }
         }
 
+        public static class ComponentModel
+        {
+            public static class DataAnnotations
+            {
+                public static readonly SystemType RequiredAttribute = new("System.ComponentModel.DataAnnotations.RequiredAttribute");
+                public static readonly SystemType ValidationAttribute = new("System.ComponentModel.DataAnnotations.ValidationAttribute");
+            }
+        }
+
         public static class Diagnostics
         {
             public static class CodeAnalysis
@@ -47,15 +56,6 @@ public partial class SystemType
             public static class Contracts
             {
                 public static readonly SystemType PureAttribute = typeof(global::System.Diagnostics.Contracts.PureAttribute);
-            }
-        }
-
-        public static class ComponentModel
-        {
-            public static class DataAnnotations
-            {
-                public static readonly SystemType RequiredAttribute = new("System.ComponentModel.DataAnnotations.RequiredAttribute");
-                public static readonly SystemType ValidationAttribute = new("System.ComponentModel.DataAnnotations.ValidationAttribute");
             }
         }
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -78,5 +78,13 @@ public partial class SystemType
     public static class Qowaiv
     {
         public static readonly SystemType Date = new("Qowaiv.Date");
+
+        public static class Validation
+        {
+            public static class DataAnnotations
+            {
+                public static readonly SystemType ValidatesAttribute = new("Qowaiv.Validation.DataAnnotations.ValidatesAttribute");
+            }
+        }
     }
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
@@ -1,6 +1,6 @@
 namespace Qowaiv.CodeAnalysis;
 
-public sealed partial class SystemType
+public sealed partial class SystemType : IEquatable<SystemType>
 {
     private SystemType(string fullName, SpecialType specialType = SpecialType.None)
     {
@@ -25,6 +25,17 @@ public sealed partial class SystemType
 
     /// <inheritdoc />
     public override string ToString() => FullName;
+
+    /// <inheritdoc />
+    public override bool Equals(object obj) => obj is SystemType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(SystemType other)
+        => FullName == other.FullName
+        && Type == other.Type;
+
+    /// <inheritdoc />
+    public override int GetHashCode() => FullName.GetHashCode();
 
     /// <summary>Casts a <see cref="System.Type"/> to a <see cref="SystemType"/>.</summary>
     public static implicit operator SystemType(Type type) => new(type.FullName, default);

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
@@ -42,5 +42,10 @@ public sealed partial class SystemType : IEquatable<SystemType>
 
     private static SystemType New(Type type, SpecialType specialType) => new(type.FullName, specialType);
 
+    public static SystemType New(ITypeSymbol type)
+        => new(type.GetFullMetaDataName(), type.SpecialType);
+
+    public static SystemType Parse(string str) => new(str);
+
     private static string Last(string[] array) => array[array.Length - 1];
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.cs
@@ -32,7 +32,7 @@ public sealed partial class SystemType : IEquatable<SystemType>
     /// <inheritdoc />
     public bool Equals(SystemType other)
         => FullName == other.FullName
-        && Type == other.Type;
+        || (Type is not SpecialType.None && Type == other.Type);
 
     /// <inheritdoc />
     public override int GetHashCode() => FullName.GetHashCode();


### PR DESCRIPTION
Validation attributes are designed to validate certain member types. When applied on other types, this is invalid, and might even crash.

Which types are supported by a validator can be defined by decorating a validator either with `[Valdates(typeof(ValidatedType))]` or `[Validates(GenericArgument = true)]` when is assumed that the the generic argument of the attribute is equal to the that is supported.

## Non-compliant
``` C#
class Model
{
    [Allowed<int>(42, 2017)]
    public string Number { get; init; }
}
```

## Compliant
``` C#
class Model
{
    [Allowed<string>("42", "2017")]
    public string Number { get; init; }
}
```