### PR TITLE
Used nested classes for cleaner code in refering to SystemTypes

### DIFF
--- a/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/UseQowaivClock.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/UseQowaivClock.cs
@@ -30,13 +30,13 @@ public sealed class UseQowaivClock() : CodeFix(Rule.UseTestableTimeProvider.Id, 
     }
 
     private static IdentifierNameSyntax Method(IPropertySymbol property)
-        => property.MemberOf(SystemType.System_DateTimeOffset)
+        => property.MemberOf(SystemType.System.DateTimeOffset)
             ? IdentifierName("NowWithOffset")
             : IdentifierName(property.Name);
 
     private static ArgumentListSyntax Arguments(IPropertySymbol property)
-        => property.MemberOf(SystemType.System_DateTimeOffset) && property.Name == "UtcNow"
-           ? ArgumentList(SeparatedList(new[] { Argument(TimeZoneInfo_Utc()) }))
+        => property.MemberOf(SystemType.System.DateTimeOffset) && property.Name == "UtcNow"
+           ? ArgumentList(SeparatedList([Argument(TimeZoneInfo_Utc())]))
            : ArgumentList(default);
 
     private static MemberAccessExpressionSyntax TimeZoneInfo_Utc() => MemberAccessExpression(

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
@@ -29,11 +29,11 @@ internal static class SymbolExtensions
 
     [Pure]
     public static bool IsAttribute(this ITypeSymbol type)
-        => type.IsAssignableTo(SystemType.System_Attribute);
+        => type.IsAssignableTo(SystemType.System.Attribute);
 
     [Pure]
     public static bool IsException(this ITypeSymbol type)
-        => type.IsAssignableTo(SystemType.System_Exception);
+        => type.IsAssignableTo(SystemType.System.Exception);
 
     [Pure]
     public static bool IsNotNullableValueType(this ITypeSymbol type)
@@ -47,16 +47,16 @@ internal static class SymbolExtensions
 
     [Pure]
     public static bool IsObsolete(this ITypeSymbol type)
-        => type.GetAttributes().Any(attr => attr.AttributeClass.Is(SystemType.System_ObsoleteAttribute));
+        => type.GetAttributes().Any(attr => attr.AttributeClass.Is(SystemType.System.ObsoleteAttribute));
 
     [Pure]
     public static bool IsObsolete(this IMethodSymbol method)
-        => method.GetAttributes().Any(attr => attr.AttributeClass.Is(SystemType.System_ObsoleteAttribute))
+        => method.GetAttributes().Any(attr => attr.AttributeClass.Is(SystemType.System.ObsoleteAttribute))
         || method.ContainingType.IsObsolete();
 
     [Pure]
     public static bool IsObsolete(this IPropertySymbol method)
-        => method.GetAttributes().Any(attr => attr.AttributeClass.Is(SystemType.System_ObsoleteAttribute))
+        => method.GetAttributes().Any(attr => attr.AttributeClass.Is(SystemType.System.ObsoleteAttribute))
         || method.ContainingType.IsObsolete();
 
     [Pure]

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
@@ -23,9 +23,9 @@ public sealed class DecoratePureFunctions() : CodingRule(Rule.DecoratePureFuncti
     }
 
     private static bool ReturnsResult(ITypeSymbol type)
-        => type.IsNot(SystemType.System_Void)
-        && type.IsNot(SystemType.System_Threading_Task)
-        && type.IsNot(SystemType.System_Threading_ValueTask);
+        => type.IsNot(SystemType.System.Void)
+        && type.IsNot(SystemType.System.Threading.Task)
+        && type.IsNot(SystemType.System.Threading.ValueTask);
 
     private static bool HasNoRefOutParemeter(IEnumerable<IParameterSymbol> parameters)
         => parameters.All(par => par.RefKind != RefKind.Out && par.RefKind != RefKind.Ref);
@@ -39,8 +39,8 @@ public sealed class DecoratePureFunctions() : CodingRule(Rule.DecoratePureFuncti
 
     private static bool Decorated(ITypeSymbol? attr)
         => attr.IsAny(
-            SystemType.System_Diagnostics_Contracts_PureAttribute,
-            SystemType.System_Diagnostics_CodeAnalysis_DoesNotReturnAttribute)
+            SystemType.System.Diagnostics.Contracts.PureAttribute,
+            SystemType.System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute)
         || DecoratedImpure(attr!);
 
     private static bool DecoratedImpure(ITypeSymbol attr)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
@@ -19,7 +19,7 @@ public sealed class DefineOnlyOneRequiredAttribute() : CodingRule(Rule.DefineOnl
         foreach (var attribute in member.Attributes)
         {
             if (attribute.Symbol is { } type
-                && type.IsAssignableTo(SystemType.System_ComponentModel_DataAnnotations_RequiredAttribute)
+                && type.IsAssignableTo(SystemType.System.ComponentModel.DataAnnotations.RequiredAttribute)
                 && ++found > 1)
             {
                 context.ReportDiagnostic(Diagnostic, attribute, member.Name());

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/ImmutablePropertiesBase.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/ImmutablePropertiesBase.cs
@@ -22,8 +22,8 @@ public abstract class ImmutablePropertiesBase(DiagnosticDescriptor supportedDiag
 
     [Pure]
     public static bool IsExcluded(INamedTypeSymbol type)
-        => type.Implements(SystemType.System_Collections_IEnumerator)
-        || type.Implements(SystemType.System_Xml_Serialization_IXmlSerializable);
+        => type.Implements(SystemType.System.Collections.IEnumerator)
+        || type.Implements(SystemType.System.Xml.Serialization.IXmlSerializable);
 
     [Pure]
     private static bool HasImmutableBase(INamedTypeSymbol? containing)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
@@ -19,7 +19,7 @@ public sealed class RequiredAttributeCannotInvalidateValueTypes() : CodingRule(R
             foreach (var attribute in member.Attributes)
             {
                 if (attribute.Symbol is { } type
-                    && type.Is(SystemType.System_ComponentModel_DataAnnotations_RequiredAttribute))
+                    && type.Is(SystemType.System.ComponentModel.DataAnnotations.RequiredAttribute))
                 {
                     context.ReportDiagnostic(Diagnostic, attribute);
                 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
@@ -41,10 +41,9 @@ public sealed class UseImmutableTypesForProperties() : ImmutablePropertiesBase(R
         => type.GetProperties().Where(p => !p.IsStatic && IsAccessible(p.DeclaredAccessibility));
 
     [Pure]
-    private static bool DefinesMutableInterface(ITypeSymbol type)
-        => type.IsAny(
-            SystemType.System_Collections_Generic_ICollection_T,
-            SystemType.System_Collections_Generic_IDictionary_TKey_TValue,
-            SystemType.System_Collections_Generic_IList_T,
-            SystemType.System_Collections_Generic_ISet_T);
+    private static bool DefinesMutableInterface(ITypeSymbol type) => type.IsAny(
+        SystemType.System.Collections.Generic.ICollection_T,
+        SystemType.System.Collections.Generic.IDictionary_TKey_TValue,
+        SystemType.System.Collections.Generic.IList_T,
+        SystemType.System.Collections.Generic.ISet_T);
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseQowaivDecimalRounding.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseQowaivDecimalRounding.cs
@@ -10,8 +10,8 @@ public sealed class UseQowaivDecimalRounding() : CodingRule(Rule.UseQowaivDecima
     {
         if (IsMathRound(context.Node.Name())
             && context.SemanticModel.GetSymbolInfo(context.Node).Symbol is IMethodSymbol method
-            && method.ReceiverType.Is(SystemType.System_Math)
-            && method.ReturnType.Is(SystemType.System_Decimal))
+            && method.ReceiverType.Is(SystemType.System.Math)
+            && method.ReturnType.Is(SystemType.System.Decimal))
         {
             context.ReportDiagnostic(Diagnostic, context.Node.Parent!.Parent!);
         }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemDateOnly.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemDateOnly.cs
@@ -33,7 +33,7 @@ public sealed class UseSystemDateOnly() : CodingRule(Rule.UseSystemDateOnly)
         foreach (var sub in syntax.SubTypes())
         {
             if (context.SemanticModel.GetTypeInfo(sub).Type is INamedTypeSymbol type
-                && (type.NotNullable() ?? type).Is(SystemType.Qowaiv_Date))
+                && (type.NotNullable() ?? type).Is(SystemType.Qowaiv.Date))
             {
                 context.ReportDiagnostic(Rule.UseSystemDateOnly, sub);
             }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseTestableTimeProvider.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseTestableTimeProvider.cs
@@ -10,7 +10,7 @@ public sealed class UseTestableTimeProvider() : CodingRule(Rule.UseTestableTimeP
     {
         if (IsDateTimeProvider(context.Node.Name())
             && context.SemanticModel.GetSymbolInfo(context.Node).Symbol is IPropertySymbol property
-            && (property.MemberOf(SystemType.System_DateTime) || property.MemberOf(SystemType.System_DateTimeOffset)))
+            && (property.MemberOf(SystemType.System.DateTime) || property.MemberOf(SystemType.System.DateTimeOffset)))
         {
             context.ReportDiagnostic(Diagnostic, context.Node.Parent!);
         }

--- a/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/SystemType.Instances.cs
@@ -2,40 +2,80 @@ namespace Qowaiv.CodeAnalysis;
 
 public partial class SystemType
 {
-    public static readonly SystemType System_Object = New(typeof(object), SpecialType.System_Object);
-    public static readonly SystemType System_String = New(typeof(string), SpecialType.System_String);
-    public static readonly SystemType System_Decimal = New(typeof(decimal), SpecialType.System_Decimal);
-    public static readonly SystemType System_DateTime = New(typeof(System.DateTime), SpecialType.System_DateTime);
-    public static readonly SystemType System_Void = New(typeof(void), SpecialType.System_Void);
+    public static class System
+    {
+        public static readonly SystemType Object = New(typeof(object), SpecialType.System_Object);
+        public static readonly SystemType String = New(typeof(string), SpecialType.System_String);
+        public static readonly SystemType Decimal = New(typeof(decimal), SpecialType.System_Decimal);
+        public static readonly SystemType DateTime = New(typeof(global::System.DateTime), SpecialType.System_DateTime);
+        public static readonly SystemType Void = New(typeof(void), SpecialType.System_Void);
 
-    public static readonly SystemType System_Collections_IEnumerator = typeof(System.Collections.IEnumerator);
-    public static readonly SystemType System_Collections_Generic_ICollection_T = New(typeof(System.Collections.Generic.ICollection<>), SpecialType.System_Collections_Generic_ICollection_T);
-    public static readonly SystemType System_Collections_Generic_IDictionary_TKey_TValue = new("System.Collections.Generic.IDictionary<TKey, TValue>");
-    public static readonly SystemType System_Collections_Generic_IList_T = New(typeof(System.Collections.Generic.IList<>), SpecialType.System_Collections_Generic_IList_T);
-    public static readonly SystemType System_Collections_Generic_ISet_T = new("System.Collections.Generic.ISet<T>");
+        public static readonly SystemType Attribute = typeof(global::System.Attribute);
+        public static readonly SystemType DateOnly = new("System.DateOnly");
+        public static readonly SystemType DateTimeOffset = typeof(global::System.DateTimeOffset);
+        public static readonly SystemType Exception = typeof(global::System.Exception);
+        public static readonly SystemType IDisposable = typeof(global::System.IDisposable);
+        public static readonly SystemType Math = typeof(global::System.Math);
+        public static readonly SystemType ObsoleteAttribute = typeof(global::System.ObsoleteAttribute);
+        public static readonly SystemType Type = typeof(global::System.Type);
 
-    public static readonly SystemType System_Collections_Generic_IReadOnlyCollection_T = new("System.Collections.Generic.IReadOnlyCollection<T>");
-    public static readonly SystemType System_Collections_Generic_IReadOnlyDictionary_TKey_TValue = new("System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>");
-    public static readonly SystemType System_Collections_Generic_IReadOnlyList_T = new("System.Collections.Generic.IReadOnlyList<T>");
-    public static readonly SystemType System_Collections_Generic_IReadOnlySet_T = new("System.Collections.Generic.IReadOnlySet<T>");
+        public static class Collections
+        {
+            public static readonly SystemType IEnumerator = typeof(global::System.Collections.IEnumerator);
 
-    public static readonly SystemType System_ComponentModel_DataAnnotations_RequiredAttribute = new("System.ComponentModel.DataAnnotations.RequiredAttribute");
+            public static class Generic
+            {
+                public static readonly SystemType ICollection_T = New(typeof(global::System.Collections.Generic.ICollection<>), SpecialType.System_Collections_Generic_ICollection_T);
+                public static readonly SystemType IDictionary_TKey_TValue = new("System.Collections.Generic.IDictionary<TKey, TValue>");
+                public static readonly SystemType IList_T = New(typeof(global::System.Collections.Generic.IList<>), SpecialType.System_Collections_Generic_IList_T);
+                public static readonly SystemType ISet_T = new("System.Collections.Generic.ISet<T>");
 
-    public static readonly SystemType System_Attribute = typeof(System.Attribute);
-    public static readonly SystemType System_DateOnly = new("System.DateOnly");
-    public static readonly SystemType System_DateTimeOffset = typeof(System.DateTimeOffset);
-    public static readonly SystemType System_Exception = typeof(System.Exception);
-    public static readonly SystemType System_IDisposable = typeof(System.IDisposable);
-    public static readonly SystemType System_Math = typeof(System.Math);
-    public static readonly SystemType System_ObsoleteAttribute = typeof(System.ObsoleteAttribute);
+                public static readonly SystemType IReadOnlyCollection_T = new("System.Collections.Generic.IReadOnlyCollection<T>");
+                public static readonly SystemType IReadOnlyDictionary_TKey_TValue = new("System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>");
+                public static readonly SystemType IReadOnlyList_T = new("System.Collections.Generic.IReadOnlyList<T>");
+                public static readonly SystemType IReadOnlySet_T = new("System.Collections.Generic.IReadOnlySet<T>");
+            }
+        }
 
-    public static readonly SystemType System_Diagnostics_CodeAnalysis_DoesNotReturnAttribute = new("System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute");
-    public static readonly SystemType System_Diagnostics_Contracts_PureAttribute = typeof(System.Diagnostics.Contracts.PureAttribute);
+        public static class Diagnostics
+        {
+            public static class CodeAnalysis
+            {
+                public static readonly SystemType DoesNotReturnAttribute = new("System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute");
+            }
 
-    public static readonly SystemType System_Threading_Task = typeof(System.Threading.Tasks.Task);
-    public static readonly SystemType System_Threading_ValueTask = typeof(System.Threading.Tasks.ValueTask);
+            public static class Contracts
+            {
+                public static readonly SystemType PureAttribute = typeof(global::System.Diagnostics.Contracts.PureAttribute);
+            }
+        }
 
-    public static readonly SystemType System_Xml_Serialization_IXmlSerializable = typeof(System.Xml.Serialization.IXmlSerializable);
+        public static class ComponentModel
+        {
+            public static class DataAnnotations
+            {
+                public static readonly SystemType RequiredAttribute = new("System.ComponentModel.DataAnnotations.RequiredAttribute");
+                public static readonly SystemType ValidationAttribute = new("System.ComponentModel.DataAnnotations.ValidationAttribute");
+            }
+        }
 
-    public static readonly SystemType Qowaiv_Date = new("Qowaiv.Date");
+        public static class Threading
+        {
+            public static readonly SystemType Task = typeof(global::System.Threading.Tasks.Task);
+            public static readonly SystemType ValueTask = typeof(global::System.Threading.Tasks.ValueTask);
+        }
+
+        public static class Xml
+        {
+            public static class Serialization
+            {
+                public static readonly SystemType IXmlSerializable = typeof(global::System.Xml.Serialization.IXmlSerializable);
+            }
+        }
+    }
+
+    public static class Qowaiv
+    {
+        public static readonly SystemType Date = new("Qowaiv.Date");
+    }
 }


### PR DESCRIPTION
References like `SystemType.System_DateOnly` are now `SystemType.System.DateOnly`.