### PR TITLE
QW0101: [Required] always allowed on Properties/Fields for JSON serializable models

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,13 +9,14 @@
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="9.0.8" />
     <PackageVersion Include="CodeAnalysis.TestTools" Version="4.0.0" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[5.0.0,)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NuGet.Packaging" Version="7.3.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/rules/QW0101.md
+++ b/rules/QW0101.md
@@ -1,6 +1,7 @@
 # QW0101: Required attribute cannot invalidate value types
 
 The `[Required]` attribute checks if the value is null. This is always true
+The `[Required]` attribute checks if the value is not null. This is always false
 for value types except for `Nullable<T>`. The use of the `[Required]` attribute
 is most likely not doing what might be expected, and should be prevented.
 

--- a/rules/QW0101.md
+++ b/rules/QW0101.md
@@ -4,6 +4,11 @@ The `[Required]` attribute checks if the value is null. This is always true
 for value types except for `Nullable<T>`. The use of the `[Required]` attribute
 is most likely not doing what might be expected, and should be prevented.
 
+An exception is made for models that are decorated with JSON serialization
+attributes, as both [System.Text.Json](https://www.nuget.org/packages/System.Text.Json)
+and [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json) take the
+`[Required]` keyword into account when deserializing.
+
 ## Non-compliant
 ``` C#
 class Model

--- a/specs/Qowaiv.CodeAnalysis.Specs/Cases/RequiredAttributeCannotInvalidateValueTypes.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Cases/RequiredAttributeCannotInvalidateValueTypes.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 class OnProperties
 {
@@ -34,3 +35,26 @@ record OnRecords([Required] int ValueType, [Required] string WithSingle); // Non
 public enum MyEnum { }
 
 public sealed class OptionalAttribute : RequiredAttribute { }
+
+[System.Text.Json.Serialization.JsonNumberHandling(JsonNumberHandling.Strict)]
+class JsonSerializableObject
+{
+    [Required]
+    public int ValueType { get; init; } // Compliant
+}
+
+class JsonSerializableProperty
+{
+    [System.Text.Json.Serialization.JsonPropertyName("value")]
+    [Required]
+    public int ValueType { get; init; } // Compliant
+}
+
+class NewtonsoftSerializable
+{
+    [Required]
+    public int ValueType { get; init; } // Compliant
+
+    [Newtonsoft.Json.JsonProperty("value")]
+    public string Value { get; init; }
+}

--- a/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Qowaiv.CodeAnalysis.Specs.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="CodeAnalysis.TestTools" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NUnit" />
   </ItemGroup>
 

--- a/specs/Qowaiv.CodeAnalysis.Specs/Rules/Required_attribute_cannot_invalidate_value_types.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/Rules/Required_attribute_cannot_invalidate_value_types.cs
@@ -7,5 +7,7 @@ public class Verify
         .ForCS()
         .AddSource(@"Cases/RequiredAttributeCannotInvalidateValueTypes.cs")
         .AddReference<System.ComponentModel.DataAnnotations.RequiredAttribute>()
+        .AddReference<System.Text.Json.Serialization.JsonPropertyNameAttribute>()
+        .AddReference<Newtonsoft.Json.JsonPropertyAttribute>()
         .Verify();
 }

--- a/specs/Qowaiv.CodeAnalysis.Specs/packages.lock.json
+++ b/specs/Qowaiv.CodeAnalysis.Specs/packages.lock.json
@@ -37,9 +37,9 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
       },
       "DotNetProjectFile.Analyzers": {
         "type": "Direct",
@@ -79,6 +79,15 @@
           "NuGet.Configuration": "7.3.1",
           "NuGet.Versioning": "7.3.1",
           "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Direct",
+        "requested": "[7.3.1, )",
+        "resolved": "7.3.1",
+        "contentHash": "vYd5vtCJ/tpMQjbAs6rrftNgeh5Ip1w7tnEsDZCpGObKgUgOxHQBekCul3TnzmbNgobvJEkDJNaec5/ZBv66Hg==",
+        "dependencies": {
+          "NuGet.Packaging": "7.3.1"
         }
       },
       "NUnit": {
@@ -482,14 +491,6 @@
         "type": "Transitive",
         "resolved": "7.3.1",
         "contentHash": "VUPAE5l/Ir4Gb3dv+v0jq0Qe4nfwxfrfiYN7QhwlGyWPXFKYXSSke1t1bV/ZYd6idtTtRDqJPM49Lt/U8NTocg=="
-      },
-      "NuGet.Protocol": {
-        "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "bYPzTqgOSsXV8AxXXFCCPtAtlxwph0DVtdM8AlaKTGLClHDx7VAlL4cCIcVl2iEzQuG1uC79SvzllvKi1grcNw==",
-        "dependencies": {
-          "NuGet.Packaging": "7.0.1"
-        }
       },
       "NuGet.Versioning": {
         "type": "Transitive",

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -53,15 +53,17 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>2.3.1</Version>
+    <Version>2.3.2</Version>
     <ToBeReleased>
       <![CDATA[
 v2.*
-- QW0101: [Required] always allowed on Properties/Fields for JSON serializable models. (FP)
+- ?
       ]]>
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
+v2.3.2
+- QW0101: [Required] always allowed on Properties/Fields for JSON serializable models. (FP)
 v2.3.1
 - QW0103: Check full type when dealing with partial classes. (FP)
 v2.3.0

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -57,7 +57,7 @@
     <ToBeReleased>
       <![CDATA[
 v2.*
-- ?
+- QW0101: [Required] always allowed on Properties/Fields for JSON serializable models. (FP)
       ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
@@ -33,7 +33,7 @@ public sealed class RequiredAttributeCannotInvalidateValueTypes() : CodingRule(R
         && DecoratedWithJsonAttribute(parent.Symbol);
 
     private static bool DecoratedWithJsonAttribute(INamedTypeSymbol? type)
-        => type?.GetAttributes().Any(IsJsonAsstribute) is true
+        => type?.GetAttributes().Any(IsJsonAttribute) is true
         || type?.GetProperties().Any(p => p.GetAttributes().Any(IsJsonAsstribute)) is true;
 
     private static bool IsJsonAttribute(AttributeData attr)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
@@ -34,7 +34,7 @@ public sealed class RequiredAttributeCannotInvalidateValueTypes() : CodingRule(R
 
     private static bool DecoratedWithJsonAttribute(INamedTypeSymbol? type)
         => type?.GetAttributes().Any(IsJsonAttribute) is true
-        || type?.GetProperties().Any(p => p.GetAttributes().Any(IsJsonAsstribute)) is true;
+        || type?.GetProperties().Any(p => p.GetAttributes().Any(IsJsonAttribute)) is true;
 
     private static bool IsJsonAttribute(AttributeData attr)
         => attr.AttributeClass?.GetFullMetaDataName() is { Length: > 0 } name

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
@@ -19,11 +19,25 @@ public sealed class RequiredAttributeCannotInvalidateValueTypes() : CodingRule(R
             foreach (var attribute in member.Attributes)
             {
                 if (attribute.Symbol is { } type
-                    && type.Is(SystemType.System.ComponentModel.DataAnnotations.RequiredAttribute))
+                    && type.Is(SystemType.System.ComponentModel.DataAnnotations.RequiredAttribute)
+                    && !DecoratedWithJsonAttribute(context))
                 {
                     context.ReportDiagnostic(Diagnostic, attribute);
                 }
             }
         }
     }
+
+    private static bool DecoratedWithJsonAttribute(SyntaxNodeAnalysisContext context)
+        => context.Node.Parent?.TryTypeDeclaration(context.SemanticModel) is { } parent
+        && DecoratedWithJsonAttribute(parent.Symbol);
+
+    private static bool DecoratedWithJsonAttribute(INamedTypeSymbol? type)
+        => type?.GetAttributes().Any(IsJsonAsstribute) is true
+        || type?.GetProperties().Any(p => p.GetAttributes().Any(IsJsonAsstribute)) is true;
+
+    private static bool IsJsonAsstribute(AttributeData attr)
+        => attr.AttributeClass?.GetFullMetaDataName() is { Length: > 0 } name
+        && (name.StartsWith("System.Text.Json.Serialization.")
+        || name.StartsWith("Newtonsoft.Json."));
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
@@ -36,7 +36,7 @@ public sealed class RequiredAttributeCannotInvalidateValueTypes() : CodingRule(R
         => type?.GetAttributes().Any(IsJsonAsstribute) is true
         || type?.GetProperties().Any(p => p.GetAttributes().Any(IsJsonAsstribute)) is true;
 
-    private static bool IsJsonAsstribute(AttributeData attr)
+    private static bool IsJsonAttribute(AttributeData attr)
         => attr.AttributeClass?.GetFullMetaDataName() is { Length: > 0 } name
         && (name.StartsWith("System.Text.Json.Serialization.")
         || name.StartsWith("Newtonsoft.Json."));


### PR DESCRIPTION
An exception is made for models that are decorated with JSON serialization attributes, as both [System.Text.Json](https://www.nuget.org/packages/System.Text.Json) and [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json) take the `[Required]` keyword into account when deserializing.

Closes #91 