### PR TITLE
Exclude some rules on test code

### DIFF
--- a/.net.csproj
+++ b/.net.csproj
@@ -11,9 +11,5 @@
     <None Include="dictionary.dic" />
     <None Include="rules/**" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="DotNetProjectFile.Analyzers.Sdk" PrivateAssets="all" />
-  </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,6 @@
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="9.0.8" />
     <PackageVersion Include="CodeAnalysis.TestTools" Version="5.0.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.12.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[5.0.0,)" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
@@ -29,7 +28,7 @@
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="DotNetProjectFile.Analyzers" Version="1.12.1" />
+    <GlobalPackageReference Include="DotNetProjectFile.Analyzers" Version="1.13.1" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 
 ## Rules
 * [**QW0001** - Use a testable Time Provider](rules/QW0001.md)
-* [**QW0003** - Decorate pure functions*](rules/QW0003.md)
+* [**QW0003** - Decorate pure functions](rules/QW0003.md)
 * [**QW0004** - Characters with Trojan Horse potential are not allowed](rules/QW0004.md)
 * [**QW0005** - Seal concrete classes unless designed for inheritance](rules/QW0005.md)
 * [**QW0006** - Only unsealed concrete classes should be decorated as inheritable](rules/QW0006.md)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 ## Configuration
 Some of the rules are not intended for (unit) test code. Unit tests that set
 `IsTestProject` to `true` are excluded. When setting `IsTestProject` is undesirable,
-a project can alternativaly set `IsTestCode` to `true` instead. It is worth to
+a project can set `IsTestCode` to `true` instead. It is worth to
 mention that only a subset of the rules is considered irrelevant for test code,
 the rest is always executed.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 
 ## Rules
 * [**QW0001** - Use a testable Time Provider](rules/QW0001.md)
-* [**QW0003** - Decorate pure functions](rules/QW0003.md)
+* [**QW0003** - Decorate pure functions*](rules/QW0003.md)
 * [**QW0004** - Characters with Trojan Horse potential are not allowed](rules/QW0004.md)
 * [**QW0005** - Seal concrete classes unless designed for inheritance](rules/QW0005.md)
 * [**QW0006** - Only unsealed concrete classes should be decorated as inheritable](rules/QW0006.md)
@@ -48,3 +48,10 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * Apply suggestions of obsolete code attribute [CS0618, CS0619](rules/ObsoleteCode.md))
 * Use Qowaiv round extensions ([QW0013](rules/QW0013.md))
 * Use Qowaiv.Clock.TimeProvider ([QW0018](rules/QW0018.md))
+
+## Configuration
+Some of the rules are not intended for (unit) test code. Unit tests that set
+`IsTestProject` to `true` are excluded. When setting `IsTestProject` undesirable,
+a project can alternativaly set `IsTestCode` to `true` instead. It is worth to
+mention that only a subset of the rules is considered irrelevant for test code,
+the rest is always executed.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 
 ## Configuration
 Some of the rules are not intended for (unit) test code. Unit tests that set
-`IsTestProject` to `true` are excluded. When setting `IsTestProject` undesirable,
+`IsTestProject` to `true` are excluded. When setting `IsTestProject` is undesirable,
 a project can alternativaly set `IsTestCode` to `true` instead. It is worth to
 mention that only a subset of the rules is considered irrelevant for test code,
 the rest is always executed.

--- a/specs/Qowaiv.CodeAnalysis.Specs/TestTools/EmptyRule.cs
+++ b/specs/Qowaiv.CodeAnalysis.Specs/TestTools/EmptyRule.cs
@@ -5,7 +5,14 @@ using Qowaiv.CodeAnalysis.Diagnostics;
 namespace Specs.TestTools;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-internal sealed class NoRule() : CodingRule(new DiagnosticDescriptor(nameof(NoRule), "No Rule", "Specs", string.Empty, DiagnosticSeverity.Warning, true))
+internal sealed class NoRule() : CodingRule(new() { Descriptor = new(
+    nameof(NoRule),
+    "No Rule",
+    "Specs",
+    string.Empty,
+    DiagnosticSeverity.Warning,
+    true)
+})
 {
     protected override void Register(AnalysisContext context) { }
 }

--- a/specs/Qowaiv.CodeAnalysis.Specs/packages.lock.json
+++ b/specs/Qowaiv.CodeAnalysis.Specs/packages.lock.json
@@ -45,9 +45,9 @@
       },
       "DotNetProjectFile.Analyzers": {
         "type": "Direct",
-        "requested": "[1.12.1, )",
-        "resolved": "1.12.1",
-        "contentHash": "ihEhH6slvFM5IibCYOdYI5EnzAkeD+2acmr8DvwvBEZ64wpIhKIdoIy2oF7JY+CQ2n+anlSLAd5Cknq3aw/rtg=="
+        "requested": "[1.13.1, )",
+        "resolved": "1.13.1",
+        "contentHash": "nDIThFLyqnihw9eTStm0oteWT31DanE/0k07TDWxcqrlG4wfEoTY4cWNr3MxLBSoXCI6MdkhUIxyrVB53yrM9A=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Direct",

--- a/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/CodingRule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/CodingRule.cs
@@ -24,7 +24,7 @@ public abstract class CodingRule(DescriptorContainer supportedDiagnostic, params
 
     /// <inheritdoc cref="AnalysisContext.RegisterSyntaxNodeAction{TLanguageKindEnum}(Action{SyntaxNodeAnalysisContext}, ImmutableArray{TLanguageKindEnum})"/>
     /// <remarks>
-    /// When diagnose on test code is diabled, the action is made conditional too.
+    /// When analysis on test code is disabled, the action is made conditional too.
     /// </remarks>
     protected void RegisterSyntaxNodeAction(
         AnalysisContext context,

--- a/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/CodingRule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/CodingRule.cs
@@ -7,7 +7,7 @@ public abstract class CodingRule(DescriptorContainer supportedDiagnostic, params
 
     public DiagnosticDescriptor Diagnostic => SupportedDiagnostics[0];
 
-    /// <summary>If enabled, the coding also applies on test code (defaultL false).</summary>
+    /// <summary>If enabled, the coding also applies on test code (default false).</summary>
     protected bool AnalyzeTestCode { get; } = supportedDiagnostic.AnalyzeTestCode;
 
     /// <inheritdoc />

--- a/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/CodingRule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/CodingRule.cs
@@ -1,18 +1,45 @@
 namespace Qowaiv.CodeAnalysis.Diagnostics;
 
-public abstract class CodingRule(DiagnosticDescriptor supportedDiagnostic, params IEnumerable<DiagnosticDescriptor> additional)
+public abstract class CodingRule(DescriptorContainer supportedDiagnostic, params IEnumerable<DiagnosticDescriptor> additional)
     : DiagnosticAnalyzer
 {
     public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [supportedDiagnostic, .. additional];
 
     public DiagnosticDescriptor Diagnostic => SupportedDiagnostics[0];
 
+    /// <summary>If enabled, the coding also applies on test code (defaultL false).</summary>
+    protected bool AnalyzeTestCode { get; } = supportedDiagnostic.AnalyzeTestCode;
+
+    /// <inheritdoc />
     public sealed override void Initialize(AnalysisContext context)
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
+
         Register(context);
     }
 
+    /// <summary>Register actions on the analysis context.</summary>
     protected abstract void Register(AnalysisContext context);
+
+    /// <inheritdoc cref="AnalysisContext.RegisterSyntaxNodeAction{TLanguageKindEnum}(Action{SyntaxNodeAnalysisContext}, ImmutableArray{TLanguageKindEnum})"/>
+    /// <remarks>
+    /// When diagnose on test code is diabled, the action is made conditional too.
+    /// </remarks>
+    protected void RegisterSyntaxNodeAction(
+        AnalysisContext context,
+        Action<SyntaxNodeAnalysisContext> action,
+        params SyntaxKind[] syntaxKinds)
+        => context.RegisterSyntaxNodeAction(Action(action), syntaxKinds);
+
+    private Action<SyntaxNodeAnalysisContext> Action(Action<SyntaxNodeAnalysisContext> action)
+        => AnalyzeTestCode
+        ? action
+        : c =>
+        {
+            if (!c.IsTestCode)
+            {
+                action(c);
+            }
+        };
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/DescriptorContainer.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/DescriptorContainer.cs
@@ -1,0 +1,26 @@
+namespace Qowaiv.CodeAnalysis.Diagnostics;
+
+/// <summary>A container/wrapper arround a <see cref="DiagnosticDescriptor"/>.</summary>
+/// <remarks>
+/// As a <see cref="DiagnosticDescriptor"/> is sealed, we need some composition
+/// to extend it.
+/// </remarks>
+public sealed class DescriptorContainer
+{
+    /// <summary>Indicates of the rule should analyze test code.</summary>
+    public bool AnalyzeTestCode { get; set; }
+
+    /// <summary>The descriptor of a <see cref="CodingRule"/>.</summary>
+    public DiagnosticDescriptor Descriptor { get; set; } = null!;
+
+    /// <inheritdoc cref="DiagnosticDescriptor.Id" />
+    public string Id => Descriptor.Id;
+
+    /// <inheritdoc cref="DiagnosticDescriptor.Category" />
+    public string Category => Descriptor.Category;
+
+    /// <inheritdoc cref="DiagnosticDescriptor.HelpLinkUri" />
+    public string HelpLinkUri => Descriptor.HelpLinkUri;
+
+    public static implicit operator DiagnosticDescriptor(DescriptorContainer container) => container.Descriptor;
+}

--- a/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/DescriptorContainer.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/DescriptorContainer.cs
@@ -1,6 +1,6 @@
 namespace Qowaiv.CodeAnalysis.Diagnostics;
 
-/// <summary>A container/wrapper arround a <see cref="DiagnosticDescriptor"/>.</summary>
+/// <summary>A container/wrapper around a <see cref="DiagnosticDescriptor"/>.</summary>
 /// <remarks>
 /// As a <see cref="DiagnosticDescriptor"/> is sealed, we need some composition
 /// to extend it.

--- a/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/DescriptorContainer.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Diagnostics/DescriptorContainer.cs
@@ -7,7 +7,7 @@ namespace Qowaiv.CodeAnalysis.Diagnostics;
 /// </remarks>
 public sealed class DescriptorContainer
 {
-    /// <summary>Indicates of the rule should analyze test code.</summary>
+    /// <summary>Indicates if the rule should analyze test code.</summary>
     public bool AnalyzeTestCode { get; set; }
 
     /// <summary>The descriptor of a <see cref="CodingRule"/>.</summary>

--- a/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext.cs
@@ -5,6 +5,12 @@ internal static class SyntaxNodeAnalysisContextExtensions
 {
     extension(SyntaxNodeAnalysisContext context)
     {
+        /// <summary>Indicates that we deal with test code.</summary>
+        public bool IsTestCode
+            => context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue($"build_property.IsTestCode", out var value)
+            && bool.TryParse(value, out var isTestCode)
+            && isTestCode;
+
         /// <summary>Report a <see cref="Diagnostic"/> about a <see cref="SyntaxNode"/>'.</summary>
         public void ReportDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode node, params object[] messageArgs)
             => context.ReportDiagnostic(

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.Analyzers.CSharp.targets
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.Analyzers.CSharp.targets
@@ -1,0 +1,11 @@
+<Project>
+
+  <PropertyGroup>
+    <IsTestCode Condition="$(IsTestCode) == '' and $(IsTestProject) == 'true'">true</IsTestCode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="IsTestCode" />
+  </ItemGroup>
+
+</Project>

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -63,7 +63,7 @@ v2.*
     <PackageReleaseNotes>
       <![CDATA[
 v2.4.0
-- Disable QW0003, QW0005, QW0006, QW0008, QW0009, QW0010, QW0011, QW0012,
+- QW0003, QW0005, QW0006, QW0008, QW0009, QW0010, QW0011, QW0012,
   QW0016, QW0103, QW0104 are disabled for test code.
 v2.3.2
 - QW0101: [Required] always allowed on Properties/Fields for JSON serializable models. (FP)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -34,8 +34,9 @@
 
   <ItemGroup Label="Package files">
     <None Update="tools/*.ps1" Pack="true" PackagePath="/" />
-    <None Include="$(MSBuildThisFileDirectory)../../design/package-icon.png" Pack="true" PackagePath="" Visible="false" />
-    <None Include="$(OutputPath)/Qowaiv.CodeAnalysis.CSharp.dll" Pack="true" PackagePath="analyzers" Visible="false" />
+    <None Include="Qowaiv.Analyzers.CSharp.targets" Pack="true" PackagePath="build/" />
+    <None Include="$(MSBuildThisFileDirectory)../../design/package-icon.png" Pack="true" PackagePath="/" Visible="false" />
+    <None Include="$(OutputPath)/Qowaiv.CodeAnalysis.CSharp.dll" Pack="true" PackagePath="analyzers/" Visible="false" />
     <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
@@ -52,7 +53,7 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>2.3.2</Version>
+    <Version>2.4.0</Version>
     <ToBeReleased>
       <![CDATA[
 v2.*
@@ -61,6 +62,9 @@ v2.*
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
+v2.4.0
+- Disable QW0003, QW0005, QW0006, QW0008, QW0009, QW0010, QW0011, QW0012,
+  QW0016, QW0103, QW0104 are disabled for test code.
 v2.3.2
 - QW0101: [Required] always allowed on Properties/Fields for JSON serializable models. (FP)
 v2.3.1

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -6,7 +6,7 @@ namespace Qowaiv.CodeAnalysis;
 
 public static partial class Rule
 {
-    public static DiagnosticDescriptor UseTestableTimeProvider => New(
+    public static DescriptorContainer UseTestableTimeProvider => New(
         id: 0001,
         title: "Use a testable Time Provider",
         message: "Use a testable (date) time provider instead.",
@@ -15,9 +15,10 @@ public static partial class Rule
             "be adjustable under test. DateTime.Now, DateTime.UtcNow, " +
             "and DateTime.Today lack this possibility.",
         category: Category.Testabilty,
-        tags: ["Test"]);
+        tags: ["Test"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor ParseShouldNotFail => New(
+    public static DescriptorContainer ParseShouldNotFail => New(
         id: 0002,
         title: "Parse should not fail",
         message: "{0}",
@@ -25,9 +26,10 @@ public static partial class Rule
             "Parsing string literals should not fail, as it will crash at runtime.",
         category: Category.RuntimeError,
         severity: DiagnosticSeverity.Error,
-        tags: ["Error"]);
+        tags: ["Error"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor DecoratePureFunctions => New(
+    public static DescriptorContainer DecoratePureFunctions => New(
         id: 0003,
         title: "Decorate pure functions",
         message: "Decorate this method with a [Pure] or [Impure] attribute.",
@@ -36,9 +38,10 @@ public static partial class Rule
             "of pure functions.",
         category: Category.Design,
         tags: ["Diagnostics", "Contracts", "Pure function"],
-        isEnabled: false);
+        isEnabled: false,
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor TrojanCharactersAreNotAllowed => New(
+    public static DescriptorContainer TrojanCharactersAreNotAllowed => New(
         id: 0004,
         title: "Characters with Trojan Horse potential are not allowed",
         message: "Trojan Horse character U+{0:X} detected.",
@@ -46,9 +49,10 @@ public static partial class Rule
             "When characters with Trojan Horse potential are found, they should be blocked " +
             "to avoid security risks to the application.",
         category: Category.Security,
-        tags: ["Trojan", "Unicode"]);
+        tags: ["Trojan", "Unicode"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor SealClasses => New(
+    public static DescriptorContainer SealClasses => New(
         id: 0005,
         title: "Seal concrete classes unless designed for inheritance",
         message: "Seal this {0} or make it explicitly inheritable.",
@@ -58,18 +62,20 @@ public static partial class Rule
             "consequence, it is considered a bad practice to unintentionally " +
             "allowing a class to be inheritable.",
         category: Category.Design,
-        tags: ["Design"]);
+        tags: ["Design"],
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor OnlyUnsealedConcreteClassesCanBeInheritable => New(
+    public static DescriptorContainer OnlyUnsealedConcreteClassesCanBeInheritable => New(
         id: 0006,
         title: "Only unsealed concrete classes should be decorated as inheritable",
         message: "Remove the [{0}] attribute.",
         description:
             "The inheritable attribute is only meant to be used on concrete classes.",
         category: Category.Design,
-        tags: ["Design"]);
+        tags: ["Design"],
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor UseFileScopedNamespaceDeclarations => New(
+    public static DescriptorContainer UseFileScopedNamespaceDeclarations => New(
         id: 0007,
         title: "Use file-scoped namespace declarations",
         message: "Use a file-scoped namespace declaration instead.",
@@ -78,9 +84,10 @@ public static partial class Rule
             "wasted horizontal space to the left of the class definition, since " +
             "it no longer needs to be indented.",
         category: Category.Design,
-        tags: ["Design"]);
+        tags: ["Design"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor DefinePropertiesAsNotNullable => New(
+    public static DescriptorContainer DefinePropertiesAsNotNullable => New(
         id: 0008,
         title: "Define properties as not-nullable for types with a defined empty state",
         message: "Define the property as not-nullable as its type has a defined empty state.",
@@ -89,9 +96,10 @@ public static partial class Rule
             "to it, because the nullable that has a value can still represent an " +
             "empty state.",
         category: Category.Design,
-        tags: ["Design", "SVO", "Value Type", "Value Object"]);
+        tags: ["Design", "SVO", "Value Type", "Value Object"],
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor DefineEnumPropertiesAsNotNullable => New(
+    public static DescriptorContainer DefineEnumPropertiesAsNotNullable => New(
         id: 0009,
         title: "Define properties as not-nullable for enums with a defined none/empty value",
         message: "Define the property as not-nullable as its type has a defined none/empty value.",
@@ -100,19 +108,21 @@ public static partial class Rule
             "to it, because the nullable that has a value can still represent an " +
             "none/empty state.",
         category: Category.Design,
-        tags: ["Design", "Enum", "Enumeration"]);
+        tags: ["Design", "Enum", "Enumeration"],
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor UseSystemDateOnly => New(
-       id: 0010,
-       title: "Use System.DateOnly instead of Qowaiv.Date",
-       message: "Use DateOnly instead of Date.",
-       description:
+    public static DescriptorContainer UseSystemDateOnly => New(
+        id: 0010,
+        title: "Use System.DateOnly instead of Qowaiv.Date",
+        message: "Use DateOnly instead of Date.",
+        description:
             "The purpose of `Qowaiv.Date` is to provide a date (only) alternative to DateTime. " +
             "Since .NET 6.0, Microsoft provides DateOnly.",
-       category: Category.Design,
-       tags: ["Design", "SVO"]);
+        category: Category.Design,
+        tags: ["Design", "SVO"],
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor DefinePropertiesAsImmutables => New(
+    public static DescriptorContainer DefinePropertiesAsImmutables => New(
         id: 0011,
         title: "Define properties as immutables",
         message: "Remove this setter, make this property init-only, or decorate the type with the mutable attribute.",
@@ -120,9 +130,10 @@ public static partial class Rule
             "Immutable types (classes, interfaces, records, structs) have multiple advantages. " +
             "To benefit from this, all properties should be defined as immutable.",
         category: Category.Design,
-        tags: ["Design", "Immutability"]);
+        tags: ["Design", "Immutability"],
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor UseImmutableTypesForProperties => New(
+    public static DescriptorContainer UseImmutableTypesForProperties => New(
         id: 0012,
         title: "Use immutable types for properties",
         message: "Use an immutable type, or decorate the type with the mutable attribute.",
@@ -130,36 +141,40 @@ public static partial class Rule
             "Immutable types (classes, interfaces, records, structs) have multiple advantages. " +
             "To benefit from this, the type of properties should be immutable.",
         category: Category.Design,
-        tags: ["Design", "Immutability"]);
+        tags: ["Design", "Immutability"],
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor UseQowaivDecimalRounding => New(
+    public static DescriptorContainer UseQowaivDecimalRounding => New(
         id: 0013,
         title: "Use Qowaiv decimal rounding",
         message: "Use Qowaiv decimal rounding.",
         description:
             "Both the extended functionality and the extension method are reasons to adopt Qowaiv decimal rounding.",
         category: Category.Design,
-        tags: ["Design", "Readability"]);
+        tags: ["Design", "Readability"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor DefineGlobalUsingStatementsSeparately => New(
+    public static DescriptorContainer DefineGlobalUsingStatementsSeparately => New(
         id: 0014,
         title: "Define global using statements separately",
         message: "Define global using statement in a separate file.",
         description:
             "For design and maintainability reasons, it is key that all global usings statements are grouped.",
         category: Category.Design,
-        tags: ["Design", "Maintainability"]);
+        tags: ["Design", "Maintainability"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor DefineGlobalUsingStatementsInSingleFile => New(
+    public static DescriptorContainer DefineGlobalUsingStatementsInSingleFile => New(
         id: 0015,
         title: "Define global using statements in single file",
         message: "Define global using statements in '{0}' only.",
         description:
             "For design and maintainability reasons, it is key that all global usings statements are grouped.",
         category: Category.Design,
-        tags: ["Design", "Maintainability"]);
+        tags: ["Design", "Maintainability"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor PreferRegularOverPositionalProperties => New(
+    public static DescriptorContainer PreferRegularOverPositionalProperties => New(
         id: 0016,
         title: "Prefer regular over positional properties",
         message: "Define {0} as {1}.",
@@ -168,9 +183,10 @@ public static partial class Rule
             "turns out to be cumbersome for public APIs. Therefor the use of " +
             "regular properties is preferred in those cases.",
         category: Category.Design,
-        tags: ["Design", "Maintainability"]);
+        tags: ["Design", "Maintainability"],
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor ApplyArithmeticOperationsOnNonNullablesOnly => New(
+    public static DescriptorContainer ApplyArithmeticOperationsOnNonNullablesOnly => New(
         id: 0017,
         title: "Apply arithmetic operations on non-nullables only",
         message: "{0} is potentially null.",
@@ -179,9 +195,10 @@ public static partial class Rule
             "outcome will be null if any of the arguments turns out to be null, " +
             "which can be confusing or a bug.",
         category: Category.Bug,
-        tags: ["nullability", "arithmetic"]);
+        tags: ["nullability", "arithmetic"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor UseQowaivClockTimeProvider => New(
+    public static DescriptorContainer UseQowaivClockTimeProvider => New(
         id: 0018,
         title: "Use Qowaiv.Clock.TimeProvider",
         message: "Use Qowaiv.Clock.TimeProvider",
@@ -189,20 +206,22 @@ public static partial class Rule
             "The purpose of `Qowaiv.Time` is to provide a time (only) alternative to DateTime. " +
             "Since .NET 6.0, Microsoft provides TimeOnly.",
         category: Category.Design,
-        tags: ["Design"]);
+        tags: ["Design"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor PreferXmlLinq => New(
-       id: 0019,
-       title: "Prefer XML to LINQ over DOM",
-       message: "Use {0} instead of {1}",
-       description:
+    public static DescriptorContainer PreferXmlLinq => New(
+        id: 0019,
+        title: "Prefer XML to LINQ over DOM",
+        message: "Use {0} instead of {1}",
+        description:
             "With the introduction of LINQ (2008) Microsoft provided a new way " +
             "of creating XML, using XDocument/XElement. Defacto, the use of " +
             "XmlDocument/XmlElement has become obsolete since then.",
-       category: Category.Design,
-       tags: ["Performance", "Clarity", "Obsolete"]);
+        category: Category.Design,
+        tags: ["Performance", "Clarity", "Obsolete"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor UseSystemTextJson => New(
+    public static DescriptorContainer UseSystemTextJson => New(
         id: 0020,
         title: "Prefer System.Text.Json over Newtonsoft.Json",
         message: "Use System.Text.Json for JSON serialization",
@@ -210,9 +229,10 @@ public static partial class Rule
             "Use System.Text.Json for JSON serialization as it is both faster, " +
             "with a smaller memory footprint, and built-in in the .NET framework.",
         category: Category.Design,
-        tags: ["Performance", "Clarity", "Obsolete"]);
+        tags: ["Performance", "Clarity", "Obsolete"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor DefineOnlyOneRequiredAttribute => New(
+    public static DescriptorContainer DefineOnlyOneRequiredAttribute => New(
         id: 0100,
         title: "Define only one Required attribute",
         message: "{0} should not be decorated with more than one required attribute",
@@ -220,9 +240,10 @@ public static partial class Rule
             "The compiler cannot enforce single usages for overridden implementations " +
             "of the [Required] attribute, but would otherwise disallow it.",
         category: Category.Bug,
-        tags: ["Data Annotations", "AttributeUsage", "Validation", "RequiredAttribute"]);
+        tags: ["Data Annotations", "AttributeUsage", "Validation", "RequiredAttribute"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor RequiredCannotInvalidateValueTypes => New(
+    public static DescriptorContainer RequiredCannotInvalidateValueTypes => New(
         id: 0101,
         title: "Required attribute cannot invalidate value types",
         message: "The value of this value type will always meet the Required constraints",
@@ -230,9 +251,10 @@ public static partial class Rule
             "The implementation of the Required attribute is to check if the " +
             "value is not null. This is always true for non-nullable value types.",
         category: Category.Bug,
-        tags: ["Data Annotations", "Validation", "RequiredAttribute"]);
+        tags: ["Data Annotations", "Validation", "RequiredAttribute"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor UseCompliantValdationAttribute => New(
+    public static DescriptorContainer UseCompliantValdationAttribute => New(
         id: 0102,
         title: "Use compliant validation attributes",
         message: "The attribute cannot validate this type",
@@ -240,9 +262,10 @@ public static partial class Rule
             "Validation attributes are designed to validate certain member types. " +
             "When applied on other types, this is invalid, and might even crash.",
         category: Category.Bug,
-        tags: ["Data Annotations", "Validation", "ValidationAttribute"]);
+        tags: ["Data Annotations", "Validation", "ValidationAttribute"],
+        analyzeTestCode: true);
 
-    public static DiagnosticDescriptor DecorateValidationAttributes => New(
+    public static DescriptorContainer DecorateValidationAttributes => New(
         id: 0103,
         title: "Decorate validation attributes",
         message: "The attribute lacks a [Validates] attribute",
@@ -251,9 +274,10 @@ public static partial class Rule
             "that can be validated, they should be decorated with the " +
             "[Validates] attribute, so that QW0102 can enforce usage.",
         category: Category.Design,
-        tags: ["Data Annotations", "Validation", "ValidationAttribute"]);
+        tags: ["Data Annotations", "Validation", "ValidationAttribute"],
+        analyzeTestCode: false);
 
-    public static DiagnosticDescriptor UseValidatesAttributeOnValidationAttributesOnly => New(
+    public static DescriptorContainer UseValidatesAttributeOnValidationAttributesOnly => New(
         id: 0104,
         title: "Use validates attribute on validation attributes only",
         message: "The [Validates] attribute has no meaning on this type",
@@ -261,28 +285,34 @@ public static partial class Rule
             "The [Validates] attribute only has meaning when defined on a " +
             "validation attribute.",
         category: Category.Bug,
-        tags: ["Data Annotations", "Validation", "ValidationAttribute"]);
+        tags: ["Data Annotations", "Validation", "ValidationAttribute"],
+        analyzeTestCode: false);
 
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
-    private static DiagnosticDescriptor New(
+    private static DescriptorContainer New(
         int id,
         string title,
         string message,
         string description,
         string[] tags,
         Category category,
+        bool analyzeTestCode,
         DiagnosticSeverity severity = DiagnosticSeverity.Warning,
         bool isEnabled = true)
 #pragma warning restore S107 // Methods should not have too many parameters
-        => new(
-            id: $"QW{id:0000}",
-            title: title,
-            messageFormat: message,
-            customTags: tags,
-            category: category.DisplayName(),
-            defaultSeverity: severity,
-            isEnabledByDefault: isEnabled,
-            description: description,
-            helpLinkUri: $"https://github.com/Qowaiv/qowaiv-analyzers/blob/main/rules/QW{id:0000}.md");
+        => new()
+        {
+            AnalyzeTestCode = analyzeTestCode,
+            Descriptor = new(
+                id: $"QW{id:0000}",
+                title: title,
+                messageFormat: message,
+                customTags: tags,
+                category: category.DisplayName(),
+                defaultSeverity: severity,
+                isEnabledByDefault: isEnabled,
+                description: description,
+                helpLinkUri: $"https://github.com/Qowaiv/qowaiv-analyzers/blob/main/rules/QW{id:0000}.md"),
+        };
 }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/ArithmeticArgumentsShouldHaveValue.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/ArithmeticArgumentsShouldHaveValue.cs
@@ -5,7 +5,8 @@ namespace Qowaiv.CodeAnalysis.Rules;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ApplyArithmeticOperationsOnNonNullablesOnly() : CodingRule(Rule.ApplyArithmeticOperationsOnNonNullablesOnly)
 {
-    protected override void Register(AnalysisContext context) => context.RegisterSyntaxNodeAction(
+    protected override void Register(AnalysisContext context) => RegisterSyntaxNodeAction(
+        context,
         Report,
         SyntaxKind.MultiplyExpression,
         SyntaxKind.DivideExpression,

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecoratePureFunctions.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class DecoratePureFunctions() : CodingRule(Rule.DecoratePureFunctions)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.MethodDeclaration);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.MethodDeclaration);
 
     private static void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecorateValidationAttributes.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DecorateValidationAttributes.cs
@@ -6,7 +6,7 @@ public sealed class DecorateValidationAttributes() : CodingRule(Rule.DecorateVal
 {
     /// <inheritdoc />
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.ClassDeclaration);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.ClassDeclaration);
 
     private void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatements.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineGlobalUsingStatements.cs
@@ -1,10 +1,10 @@
 namespace Qowaiv.CodeAnalysis.Rules;
 
-public abstract class DefineGlobalUsingStatements(DiagnosticDescriptor supportedDiagnostic)
+public abstract class DefineGlobalUsingStatements(DescriptorContainer supportedDiagnostic)
     : CodingRule(supportedDiagnostic)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.UsingDirective);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.UsingDirective);
 
     protected abstract void Report(SyntaxNodeAnalysisContext context);
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefineOnlyOneRequiredAttribute.cs
@@ -4,7 +4,8 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class DefineOnlyOneRequiredAttribute() : CodingRule(Rule.DefineOnlyOneRequiredAttribute)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(
+        => RegisterSyntaxNodeAction(
+            context,
             Report,
             SyntaxKind.PropertyDeclaration,
             SyntaxKind.FieldDeclaration,

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsImmutables.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsImmutables.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class DefinePropertiesAsImmutables() : ImmutablePropertiesBase(Rule.DefinePropertiesAsImmutables)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.PropertyDeclaration);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.PropertyDeclaration);
 
     private void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsNotNullable.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsNotNullable.cs
@@ -35,10 +35,10 @@ public sealed class DefinePropertiesAsNotNullable() : CodingRule(
         }
     }
 
-    private static DiagnosticDescriptor? Description(INamedTypeSymbol type)
+    private static DescriptorContainer? Description(INamedTypeSymbol type)
         => EnumDefaultIsNoneOrEmpty(type) ?? DefaultIsEmpty(type);
 
-    private static DiagnosticDescriptor? EnumDefaultIsNoneOrEmpty(INamedTypeSymbol type)
+    private static DescriptorContainer? EnumDefaultIsNoneOrEmpty(INamedTypeSymbol type)
     {
         return type.TypeKind == TypeKind.Enum && type.GetMembers().Any(IsNoneOrEmpty)
             ? Rule.DefineEnumPropertiesAsNotNullable
@@ -50,7 +50,7 @@ public sealed class DefinePropertiesAsNotNullable() : CodingRule(
              && ("NONE".Matches(field.Name) || "EMPTY".Matches(field.Name));
     }
 
-    private static DiagnosticDescriptor? DefaultIsEmpty(INamedTypeSymbol type)
+    private static DescriptorContainer? DefaultIsEmpty(INamedTypeSymbol type)
     {
         return type.GetMembers("Empty").Any(s => IsReadOnlyProperty(s) || IsReadOnlyField(s))
             ? Rule.DefinePropertiesAsNotNullable

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsNotNullable.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/DefinePropertiesAsNotNullable.cs
@@ -7,8 +7,8 @@ public sealed class DefinePropertiesAsNotNullable() : CodingRule(
 {
     protected override void Register(AnalysisContext context)
     {
-        context.RegisterSyntaxNodeAction(ReportProperty, SyntaxKind.PropertyDeclaration);
-        context.RegisterSyntaxNodeAction(ReportRecord, SyntaxKind.RecordDeclaration);
+        RegisterSyntaxNodeAction(context, ReportProperty, SyntaxKind.PropertyDeclaration);
+        RegisterSyntaxNodeAction(context, ReportRecord, SyntaxKind.RecordDeclaration);
     }
 
     private static void ReportProperty(SyntaxNodeAnalysisContext context)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/ImmutablePropertiesBase.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/ImmutablePropertiesBase.cs
@@ -1,6 +1,6 @@
 namespace Qowaiv.CodeAnalysis.Rules;
 
-public abstract class ImmutablePropertiesBase(DiagnosticDescriptor supportedDiagnostic)
+public abstract class ImmutablePropertiesBase(DescriptorContainer supportedDiagnostic)
     : CodingRule(supportedDiagnostic)
 {
     [Pure]

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/PreferRegularOverPositionalProperties.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/PreferRegularOverPositionalProperties.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class PreferRegularOverPositionalProperties() : CodingRule(Rule.PreferRegularOverPositionalProperties)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.RecordDeclaration);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.RecordDeclaration);
 
     private void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/RequiredAttributeCannotInvalidateValueTypes.cs
@@ -4,7 +4,8 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class RequiredAttributeCannotInvalidateValueTypes() : CodingRule(Rule.RequiredCannotInvalidateValueTypes)
 {
     protected override void Register(AnalysisContext context)
-     => context.RegisterSyntaxNodeAction(
+     => RegisterSyntaxNodeAction(
+            context,
             Report,
             SyntaxKind.PropertyDeclaration,
             SyntaxKind.FieldDeclaration,

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/SealClasses.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/SealClasses.cs
@@ -6,7 +6,7 @@ public sealed class SealClasses() : CodingRule(
     Rule.OnlyUnsealedConcreteClassesCanBeInheritable)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.ClassDeclaration, SyntaxKind.RecordDeclaration);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.ClassDeclaration, SyntaxKind.RecordDeclaration);
 
     private static void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseCompliantValdationAttribute.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseCompliantValdationAttribute.cs
@@ -6,7 +6,8 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class UseCompliantValdationAttribute() : CodingRule(Rule.UseCompliantValdationAttribute)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(
+        => RegisterSyntaxNodeAction(
+            context,
             Report,
             SyntaxKind.PropertyDeclaration,
             SyntaxKind.FieldDeclaration,

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseFileScopedNamespaceDeclarations.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseFileScopedNamespaceDeclarations.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class UseFileScopedNamespaceDeclarations() : CodingRule(Rule.UseFileScopedNamespaceDeclarations)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.NamespaceDeclaration);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.NamespaceDeclaration);
 
     private void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class UseImmutableTypesForProperties() : ImmutablePropertiesBase(Rule.UseImmutableTypesForProperties)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.PropertyDeclaration);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.PropertyDeclaration);
 
     private void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseQowaivClockTimeProvider.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseQowaivClockTimeProvider.cs
@@ -5,8 +5,8 @@ public sealed class UseQowaivClockTimeProvider() : CodingRule(Rule.UseQowaivCloc
 {
     protected override void Register(AnalysisContext context)
     {
-        context.RegisterSyntaxNodeAction(ReportArgumentList, SyntaxKind.ArgumentList);
-        context.RegisterSyntaxNodeAction(ReportAssignment, SyntaxKind.SimpleAssignmentExpression);
+        RegisterSyntaxNodeAction(context, ReportArgumentList, SyntaxKind.ArgumentList);
+        RegisterSyntaxNodeAction(context, ReportAssignment, SyntaxKind.SimpleAssignmentExpression);
     }
 
     private void ReportArgumentList(SyntaxNodeAnalysisContext context)

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseQowaivDecimalRounding.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseQowaivDecimalRounding.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class UseQowaivDecimalRounding() : CodingRule(Rule.UseQowaivDecimalRounding)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.IdentifierName);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.IdentifierName);
 
     private void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemTextJson.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseSystemTextJson.cs
@@ -16,7 +16,7 @@ public sealed class UseSystemTextJson() : ObsoleteTypes(
 {
     protected override void Register(AnalysisContext context)
     {
-        context.RegisterSyntaxNodeAction(ReportExpressionStatement, SyntaxKind.ExpressionStatement);
+        RegisterSyntaxNodeAction(context, ReportExpressionStatement, SyntaxKind.ExpressionStatement);
         base.Register(context);
     }
 

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseTestableTimeProvider.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseTestableTimeProvider.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.CodeAnalysis.Rules;
 public sealed class UseTestableTimeProvider() : CodingRule(Rule.UseTestableTimeProvider)
 {
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.IdentifierName);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.IdentifierName);
 
     private void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseValidatesAttributeOnValidationAttributesOnly.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Rules/UseValidatesAttributeOnValidationAttributesOnly.cs
@@ -7,7 +7,7 @@ public sealed class UseValidatesAttributeOnValidationAttributesOnly()
 {
     /// <inheritdoc />
     protected override void Register(AnalysisContext context)
-        => context.RegisterSyntaxNodeAction(Report, SyntaxKind.ClassDeclaration, SyntaxKind.RecordDeclaration);
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.ClassDeclaration, SyntaxKind.RecordDeclaration);
 
     private void Report(SyntaxNodeAnalysisContext context)
     {

--- a/src/Qowaiv.CodeAnalysis.CSharp/Shared/ObsoleteTypes.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Shared/ObsoleteTypes.cs
@@ -1,6 +1,6 @@
 namespace Qowaiv.CodeAnalysis.Shared;
 
-public abstract class ObsoleteTypes(ImmutableArray<SyntaxKind> syntaxKinds, DiagnosticDescriptor supportedDiagnostic, params DiagnosticDescriptor[] additional)
+public abstract class ObsoleteTypes(ImmutableArray<SyntaxKind> syntaxKinds, DescriptorContainer supportedDiagnostic, params DiagnosticDescriptor[] additional)
     : CodingRule(supportedDiagnostic, additional)
 {
     protected abstract void Report(SyntaxNodeAnalysisContext context, SyntaxNode node, INamedTypeSymbol type);
@@ -9,20 +9,20 @@ public abstract class ObsoleteTypes(ImmutableArray<SyntaxKind> syntaxKinds, Diag
     {
         foreach (var kind in SyntaxKinds)
         {
-            context.RegisterSyntaxNodeAction(
-                kind switch
-                {
-                    SyntaxKind.Attribute => ReportAttribute,
-                    SyntaxKind.FieldDeclaration => ReportField,
-                    SyntaxKind.MethodDeclaration => ReportMethod,
-                    SyntaxKind.ParameterList => ReportParameterList,
-                    SyntaxKind.ObjectCreationExpression => ReportObjectCreation,
-                    SyntaxKind.PropertyDeclaration => ReportProperty,
-                    SyntaxKind.SimpleBaseType => ReportSimpleBaseType,
-                    _ => throw new NotSupportedException($"Syntax Kind {kind} is not supported."),
-                },
-                kind);
+            RegisterSyntaxNodeAction(context, Action(kind), kind);
         }
+
+        Action<SyntaxNodeAnalysisContext> Action(SyntaxKind kind) => kind switch
+        {
+            SyntaxKind.Attribute => ReportAttribute,
+            SyntaxKind.FieldDeclaration => ReportField,
+            SyntaxKind.MethodDeclaration => ReportMethod,
+            SyntaxKind.ParameterList => ReportParameterList,
+            SyntaxKind.ObjectCreationExpression => ReportObjectCreation,
+            SyntaxKind.PropertyDeclaration => ReportProperty,
+            SyntaxKind.SimpleBaseType => ReportSimpleBaseType,
+            _ => throw new NotSupportedException($"Syntax Kind {kind} is not supported."),
+        };
     }
 
     private void ReportAttribute(SyntaxNodeAnalysisContext context)

--- a/src/Qowaiv.CodeAnalysis.CSharp/packages.lock.json
+++ b/src/Qowaiv.CodeAnalysis.CSharp/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETStandard,Version=v2.0": {
       "DotNetProjectFile.Analyzers": {
         "type": "Direct",
-        "requested": "[1.12.1, )",
-        "resolved": "1.12.1",
-        "contentHash": "ihEhH6slvFM5IibCYOdYI5EnzAkeD+2acmr8DvwvBEZ64wpIhKIdoIy2oF7JY+CQ2n+anlSLAd5Cknq3aw/rtg=="
+        "requested": "[1.13.1, )",
+        "resolved": "1.13.1",
+        "contentHash": "nDIThFLyqnihw9eTStm0oteWT31DanE/0k07TDWxcqrlG4wfEoTY4cWNr3MxLBSoXCI6MdkhUIxyrVB53yrM9A=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
Some rules (like [QW0003: Decorate Pure functions](https://github.com/Qowaiv/qowaiv-analyzers/blob/main/rules/QW0003.md)) are meaningless to test code. Others (Like [QW0007: Use file-scoped namespaces](https://github.com/Qowaiv/qowaiv-analyzers/blob/main/rules/QW0007.md)) benefit all code.

To reduce noise, and the need to exclude some rules from test code, I've added a way to detect (see updated README.md) if we're dealing with test code or not. Based on that flag, some code is not checked for rules which I think being compliant to that rule for test code is pointless. I hope you like the improvements.