### PR TITLE
GenerateGUID with adjusted await scope

### DIFF
--- a/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/GenerateGuid.cs
+++ b/src/Qowaiv.CodeAnalysis.CSharp/CodeFixes/GenerateGuid.cs
@@ -15,7 +15,7 @@ namespace Qowaiv.CodeAnalysis.CodeFixes
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            if (await context.ChangeDocumentContext() is { } document && Node(document.Node) is { } node)
+            if ((await context.ChangeDocumentContext() is { } document) && Node(document.Node) is { } node)
             {
                 document.RegisterFix("Generate GUID", context, _ => Change(node, document));
             }

--- a/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/src/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
     <ToBeReleased>
       <![CDATA[
 v*
@@ -62,6 +62,8 @@ v*
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
+V2.5.1
+- GenerateGuid with adjusted await scope. (BUG)
 v2.5.0
 - QW0012: Exclude Qowaiv.DomainModel.Aggregate<,>. (FP)
 - QW0021: Use leading zeros to define date constants. (NEW RULE)


### PR DESCRIPTION
Due to the too broad scope of the `await`, the analysis to include `Generate GUID` always returned `false`.