### PR TITLE
Prefer strongly typed identifiers over primitives

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="DotNetProjectFile.Analyzers" Version="1.14.1" />
+    <GlobalPackageReference Include="DotNetProjectFile.Analyzers" Version="1.15.0" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" />
   </ItemGroup>

--- a/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
+++ b/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
@@ -13,7 +13,7 @@ internal static class SymbolExtensions
     [Pure]
     public static bool Is(this ITypeSymbol? symbol, SystemType type)
         => symbol is { } && symbol.IsMatch(type);
-
+    
     [Pure]
     public static bool IsAny(this ITypeSymbol? symbol, params SystemType[] types)
         => Array.Exists(types, symbol.Is);

--- a/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
+++ b/Qowaiv.CodeAnalysis.CSharp/Extensions/Microsoft.CodeAnalysis.ISymbol.cs
@@ -2,6 +2,33 @@ namespace Microsoft.CodeAnalysis;
 
 internal static class SymbolExtensions
 {
+    extension(ISymbol symbol)
+    {
+        // https://github.com/dotnet/roslyn/blob/2a594fa2157a734a988f7b5dbac99484781599bd/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs#L93
+        [ExcludeFromCodeCoverage]
+        public ImmutableArray<ISymbol> ExplicitOrImplicitInterfaceImplementations
+        {
+            get
+            {
+                if (symbol.Kind is not SymbolKind.Method and not SymbolKind.Property and not SymbolKind.Event)
+                {
+                    return [];
+                }
+
+                var containingType = symbol.ContainingType;
+
+                var query =
+                    from iface in containingType.AllInterfaces
+                    from interfaceMember in iface.GetMembers()
+                    let impl = containingType.FindImplementationForInterfaceMember(interfaceMember)
+                    where SymbolEqualityComparer.Default.Equals(symbol, impl)
+                    select interfaceMember;
+
+                return [.. query];
+            }
+        }
+    }
+
     [Pure]
     public static bool Equals(this ITypeSymbol type, ITypeSymbol other, bool includeNullability)
         => type.Equals(other, includeNullability ? SymbolEqualityComparer.IncludeNullability : SymbolEqualityComparer.Default);
@@ -13,7 +40,7 @@ internal static class SymbolExtensions
     [Pure]
     public static bool Is(this ITypeSymbol? symbol, SystemType type)
         => symbol is { } && symbol.IsMatch(type);
-    
+
     [Pure]
     public static bool IsAny(this ITypeSymbol? symbol, params SystemType[] types)
         => Array.Exists(types, symbol.Is);
@@ -30,7 +57,7 @@ internal static class SymbolExtensions
 
     [Pure]
     public static bool Implements(this ITypeSymbol? symbol, SystemType @interface)
-        => symbol is { } && symbol.AllInterfaces().Any(i => i.Is(@interface));
+        => symbol is { } && symbol.AllInterfaces.Any(i => i.Is(@interface));
 
     [Pure]
     public static bool IsAttribute(this ITypeSymbol type)
@@ -119,22 +146,6 @@ internal static class SymbolExtensions
         {
             yield return current;
             current = current.BaseType;
-        }
-    }
-
-    [Pure]
-    public static IEnumerable<INamedTypeSymbol> AllInterfaces(this ITypeSymbol? type)
-    {
-        if (type is null) yield break;
-
-        foreach (var @interface in type.Interfaces)
-        {
-            yield return @interface;
-
-            foreach (var sub in @interface.AllInterfaces())
-            {
-                yield return sub;
-            }
         }
     }
 

--- a/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -61,7 +61,7 @@ v*
 - QW0026: Provide UUID values. (NEW RULE)
 - QW0027: Create UUID's using Uuid.Parse or Uuid.Empty. (NEW RULE)
 - QW0028: Prefer strongly typed identifiers over GUIDs. (NEW RULE)
-- QW0029: Prefer strongly typed identifiers over primitives
+- QW0029: Prefer strongly typed identifiers over primitives. (NEW RULE)
       ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
+++ b/Qowaiv.CodeAnalysis.CSharp/Qowaiv.CodeAnalysis.CSharp.csproj
@@ -61,6 +61,7 @@ v*
 - QW0026: Provide UUID values. (NEW RULE)
 - QW0027: Create UUID's using Uuid.Parse or Uuid.Empty. (NEW RULE)
 - QW0028: Prefer strongly typed identifiers over GUIDs. (NEW RULE)
+- QW0029: Prefer strongly typed identifiers over primitives
       ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/Qowaiv.CodeAnalysis.CSharp/README.md
+++ b/Qowaiv.CodeAnalysis.CSharp/README.md
@@ -29,6 +29,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) (s
 * [**QW0026** - Provide UUID values](https://github.com/Qowaiv/qowaiv-analyzers/tree/main/rules/QW0026.md)
 * [**QW0027** - Create UUID's using Uuid.Parse or Uuid.Empty](https://github.com/Qowaiv/qowaiv-analyzers/tree/main/rules/QW0027.md)
 * [**QW0028** - Prefer strongly typed identifiers over GUIDs](https://github.com/Qowaiv/qowaiv-analyzers/tree/main/rules/QW0028.md)
+* [**QW0029** - Prefer strongly typed identifiers over primitives](https://github.com/Qowaiv/qowaiv-analyzers/tree/main/rules/QW0029.md)
 
 ### Data Annotation rules
 * [**QW0100** - Define only one Required attribute](https://github.com/Qowaiv/qowaiv-analyzers/tree/main/rules/QW0100.md)

--- a/Qowaiv.CodeAnalysis.CSharp/Rule.cs
+++ b/Qowaiv.CodeAnalysis.CSharp/Rule.cs
@@ -310,6 +310,17 @@ public static partial class Rule
         tags: ["primitive obsession", "GUID", "UUID", "strongly typed", "ID", "identifier"],
         analyzeTestCode: false);
 
+    public static DescriptorContainer PreferStronglyTypedIdOverPrimitives => New(
+       id: 0029,
+       title: "Prefer strongly typed identifiers over primitives",
+       message: "Use a strongly typed identifier instead",
+       description:
+           "To reduce primitive obsession, use strongly typed identifiers " +
+           "instead of primitives such as int's and string's.",
+       category: Category.Design,
+       tags: ["primitive obsession", "string", "int", "long", "strongly typed", "ID", "identifier"],
+       analyzeTestCode: false);
+
     public static DescriptorContainer DefineOnlyOneRequiredAttribute => New(
         id: 0100,
         title: "Define only one Required attribute",

--- a/Qowaiv.CodeAnalysis.CSharp/Rules/PreferStronglyTypedIdOverGuid.cs
+++ b/Qowaiv.CodeAnalysis.CSharp/Rules/PreferStronglyTypedIdOverGuid.cs
@@ -12,7 +12,7 @@ public sealed class PreferStronglyTypedIdOverGuid() : CodingRule(Rule.PreferStro
             {
                 IsInstance: true,
                 IsObsolete: false,
-                IsOverride: false,
+                IsContractual: false,
                 Accessibility: Accessibility.Public,
                 DeclaringType.Accessibility: Accessibility.Public,
                 Symbol.Type: INamedTypeSymbol type,

--- a/Qowaiv.CodeAnalysis.CSharp/Rules/PreferStronglyTypedIdOverPrimitives.cs
+++ b/Qowaiv.CodeAnalysis.CSharp/Rules/PreferStronglyTypedIdOverPrimitives.cs
@@ -1,0 +1,47 @@
+namespace Qowaiv.CodeAnalysis.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PreferStronglyTypedIdOverPrimitives() : CodingRule(Rule.PreferStronglyTypedIdOverPrimitives)
+{
+    protected override void Register(AnalysisContext context)
+        => RegisterSyntaxNodeAction(context, Report, SyntaxKind.PropertyDeclaration);
+
+    private void Report(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node.PropertyDeclaration(context.SemanticModel) is
+            {
+                IsInstance: true,
+                IsObsolete: false,
+                IsOverride: false,
+                Accessibility: Accessibility.Public,
+                DeclaringType.Accessibility: Accessibility.Public,
+                Symbol.Type: INamedTypeSymbol type,
+            } property
+            && (property.Attributes.Any(IsKey) || HasIdName(property.Name))
+            && IsPrimitive(type)
+            && property.Attributes.None(IsPrimitiveRequired))
+        {
+            context.ReportDiagnostic(Diagnostic, property.PropertyType);
+        }
+    }
+
+    private static bool HasIdName(string name)
+        => name.Matches("ID")
+        || name.EndsWith("Id")
+        || name.EndsWith("ID");
+
+    private static bool IsKey(AttributeDecoration decoration)
+        => decoration.HasName("Key")
+        || decoration.HasName("PrimaryKey")
+        || decoration.HasName("ForeignKey");
+
+    private static bool IsPrimitiveRequired(AttributeDecoration decoration)
+        => decoration.HasName("PrimitiveRequired");
+
+    private static bool IsPrimitive(INamedTypeSymbol type) => type.SpecialType
+        is SpecialType.System_String
+        or SpecialType.System_Int32
+        or SpecialType.System_UInt32
+        or SpecialType.System_Int64
+        or SpecialType.System_UInt64;
+}

--- a/Qowaiv.CodeAnalysis.CSharp/Rules/PreferStronglyTypedIdOverPrimitives.cs
+++ b/Qowaiv.CodeAnalysis.CSharp/Rules/PreferStronglyTypedIdOverPrimitives.cs
@@ -12,7 +12,7 @@ public sealed class PreferStronglyTypedIdOverPrimitives() : CodingRule(Rule.Pref
             {
                 IsInstance: true,
                 IsObsolete: false,
-                IsOverride: false,
+                IsContractual: false,
                 Accessibility: Accessibility.Public,
                 DeclaringType.Accessibility: Accessibility.Public,
                 Symbol.Type: INamedTypeSymbol type,

--- a/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
+++ b/Qowaiv.CodeAnalysis.CSharp/Rules/UseImmutableTypesForProperties.cs
@@ -9,7 +9,7 @@ public sealed class UseImmutableTypesForProperties() : ImmutablePropertiesBase(R
     private void Report(SyntaxNodeAnalysisContext context)
     {
         var property = context.Node.PropertyDeclaration(context.SemanticModel);
-        if (!property.IsOverride
+        if (!property.IsContractual
             && property.DeclaringType.Symbol?.IsAssignableTo(SystemType.System.Attribute) is false
             && IsApplicable(property)
             && IsMutable(property.PropertyType))
@@ -19,16 +19,16 @@ public sealed class UseImmutableTypesForProperties() : ImmutablePropertiesBase(R
     }
 
     [Pure]
+    private static bool ExcludeType(INamedTypeSymbol symbol)
+      => symbol.Name.StartsWith("Immutable")
+      || symbol.ContainingNamespace.GetFullMetaDataName() == "System.Collections.Frozen";
+
+    [Pure]
     private static bool IsMutable(TypeNode type)
         => type.IsArray
         || (type.Symbol is { TypeKind: not TypeKind.Delegate } symbol
             && !ExcludeType(symbol)
             && IsMutable(symbol));
-
-    [Pure]
-    private static bool ExcludeType(INamedTypeSymbol symbol)
-        => symbol.Name.StartsWith("Immutable")
-        || symbol.ContainingNamespace.GetFullMetaDataName() == "System.Collections.Frozen";
 
     [Pure]
     private static bool IsMutable(INamedTypeSymbol type) => type

--- a/Qowaiv.CodeAnalysis.CSharp/Syntax/PropertyDeclaration.cs
+++ b/Qowaiv.CodeAnalysis.CSharp/Syntax/PropertyDeclaration.cs
@@ -39,6 +39,12 @@ public sealed class PropertyDeclaration : SyntaxAbstraction<IPropertySymbol>
         => Symbol is { } symbol
         && symbol.IsObsolete();
 
+    /// <summary>True when defined by an interface, or base class.</summary>
+    public bool IsContractual
+        => !Modifiers.Contains(SyntaxKind.NewKeyword)
+        && (IsOverride
+            || Symbol is { ExplicitOrImplicitInterfaceImplementations.Length: > 0 });
+
     public TypeNode PropertyType => field ??= TypedNode.Type.TypeNode(SemanticModel);
 
     public TypeDeclaration DeclaringType

--- a/Qowaiv.CodeAnalysis.CSharp/packages.lock.json
+++ b/Qowaiv.CodeAnalysis.CSharp/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETStandard,Version=v2.0": {
       "DotNetProjectFile.Analyzers": {
         "type": "Direct",
-        "requested": "[1.14.1, )",
-        "resolved": "1.14.1",
-        "contentHash": "lGfhtsa3HBWDNnt1PhvBqqtQEQQrgi4WvB7uKbbq9X069RMqzhWe+7h7TCp7vzAt6VMAE528SKRACOkMbZtc2A=="
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "gTwbvBCbTOBFsGI63Uau2Ovlcgm66ln0hGS00DCENz+BB8PMqlQm96ajTKKtod2S66xF+MFMUl37HNsKULnzwQ=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Direct",

--- a/Qowaiv.CodeAnalysis.Specs/Cases/PreferStronglyTypedIdOverGuid.cs
+++ b/Qowaiv.CodeAnalysis.Specs/Cases/PreferStronglyTypedIdOverGuid.cs
@@ -32,6 +32,23 @@ public class PublicCompliant(Guid id)
     }
 }
 
+public class ByInterface : Identity
+{
+    public Guid Id { get; init; }
+}
+
+public class ObsoleteCode
+{
+    [Obsolete]
+    public Guid Id { get; init; }
+}
+
+public interface Identity
+{
+    [PrimitiveRequired]
+    Guid Id { get; }
+}
+
 internal class InternalCompliant
 {
     public Guid Id { get; init; }

--- a/Qowaiv.CodeAnalysis.Specs/Cases/PreferStronglyTypedIdOverPrimitives.cs
+++ b/Qowaiv.CodeAnalysis.Specs/Cases/PreferStronglyTypedIdOverPrimitives.cs
@@ -1,0 +1,64 @@
+using System;
+
+public class Noncompliant
+{
+    [Key]
+    public string Key { get; init; } // Noncompliant {{Use a strongly typed identifier instead}}
+    //     ^^^^^^
+
+    [PrimaryKey]
+    public string PrimaryKey { get; init; } // Noncompliant
+
+    [ForeignKey]
+    public string ForeignKey { get; init; } // Noncompliant
+
+    public int Id { get; init; } // Noncompliant
+
+    public int ID { get; init; } // Noncompliant
+
+    public int EndsWithId { get; init; } // Noncompliant
+
+    public int EndsWithID { get; init; } // Noncompliant
+
+    [Key]
+    public uint UInt32 { get; init; } // Noncompliant
+
+    [Key]
+    public long Int64 { get; init; } // Noncompliant
+
+    [Key]
+    public ulong UInt64 { get; init; } // Noncompliant
+}
+
+public class PublicCompliant(int id)
+{
+    public Guid Id { get; init; } //   Compliant {{Id but not a primitive.}}
+
+    public string Property { get; init; } // Compliant {{Not an ID.}}
+
+    [PrimitiveRequired]
+    [Key]
+    public int Primitive { get; init; }  //  Compliant {{ID with [PrimitiveRequired].}}
+
+    private class PrivateCompliant
+    {
+        public int Id { get; init; }
+    }
+
+    public void InMethod(Guid id) { }
+
+    protected class ProtectedCompliant
+    {
+        public int Id { get; init; }
+    }
+}
+
+internal class InternalCompliant
+{
+    public int Id { get; init; }
+}
+
+internal sealed class KeyAttribute : Attribute;
+internal sealed class PrimaryKeyAttribute : Attribute;
+internal sealed class ForeignKeyAttribute : Attribute;
+internal sealed class PrimitiveRequiredAttribute : Attribute;

--- a/Qowaiv.CodeAnalysis.Specs/Cases/PreferStronglyTypedIdOverPrimitives.cs
+++ b/Qowaiv.CodeAnalysis.Specs/Cases/PreferStronglyTypedIdOverPrimitives.cs
@@ -53,6 +53,23 @@ public class PublicCompliant(int id)
     }
 }
 
+public class ByInterface : Identity
+{
+    public long Id { get; init; }
+}
+
+public class ObsoleteCode
+{
+    [Obsolete]
+    public string Id { get; init; }
+}
+
+public interface Identity
+{
+    [PrimitiveRequired]
+    long Id { get; }
+}
+
 internal class InternalCompliant
 {
     public int Id { get; init; }

--- a/Qowaiv.CodeAnalysis.Specs/Rules/Prefer_strongly_typed_ID_over_primitives.cs
+++ b/Qowaiv.CodeAnalysis.Specs/Rules/Prefer_strongly_typed_ID_over_primitives.cs
@@ -1,0 +1,10 @@
+namespace Rules.Prefer_strongly_typed_ID_over_primitives;
+
+public class Verify
+{
+    [Test]
+    public void Rule() => new PreferStronglyTypedIdOverPrimitives()
+        .ForCS()
+        .AddSource(@"Cases/PreferStronglyTypedIdOverPrimitives.cs")
+        .Verify();
+}

--- a/Qowaiv.CodeAnalysis.Specs/packages.lock.json
+++ b/Qowaiv.CodeAnalysis.Specs/packages.lock.json
@@ -45,9 +45,9 @@
       },
       "DotNetProjectFile.Analyzers": {
         "type": "Direct",
-        "requested": "[1.14.1, )",
-        "resolved": "1.14.1",
-        "contentHash": "lGfhtsa3HBWDNnt1PhvBqqtQEQQrgi4WvB7uKbbq9X069RMqzhWe+7h7TCp7vzAt6VMAE528SKRACOkMbZtc2A=="
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "gTwbvBCbTOBFsGI63Uau2Ovlcgm66ln0hGS00DCENz+BB8PMqlQm96ajTKKtod2S66xF+MFMUl37HNsKULnzwQ=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Direct",

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * [**QW0026** - Provide UUID values](rules/QW0026.md)
 * [**QW0027** - Create UUID's using Uuid.Parse or Uuid.Empty](rules/QW0027.md)
 * [**QW0028** - Prefer strongly typed identifiers over GUIDs](rules/QW0028.md)
+* [**QW0028** - Prefer strongly typed identifiers over primitives](rules/QW0029.md)
 
 ### Data Annotation rules
 * [**QW0100** - Define only one Required attribute](rules/QW0100.md)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 * [**QW0026** - Provide UUID values](rules/QW0026.md)
 * [**QW0027** - Create UUID's using Uuid.Parse or Uuid.Empty](rules/QW0027.md)
 * [**QW0028** - Prefer strongly typed identifiers over GUIDs](rules/QW0028.md)
-* [**QW0028** - Prefer strongly typed identifiers over primitives](rules/QW0029.md)
+* [**QW0029** - Prefer strongly typed identifiers over primitives](rules/QW0029.md)
 
 ### Data Annotation rules
 * [**QW0100** - Define only one Required attribute](rules/QW0100.md)

--- a/rules/QW0029.md
+++ b/rules/QW0029.md
@@ -1,0 +1,39 @@
+# QW0029: Prefer strongly typed identifiers over primitives
+Primitives like `int`, `long`, and `string` are commonly used as identifiers
+for storing records and objects in databases.
+
+In code, it is preferred to use strongly typed identifiers instead. This allows
+for strict distinction between different types of identifiers, thereby reducing
+[primitive obsession](https://en.wikipedia.org/wiki/Design_smell).
+
+If the primitive is required elsewhere in the system, making it hard or
+inconvenient to change it to a strongly typed identifier, decorate it with the
+`[PrimitiveRequired]` attribute. In this case the rule will not flag this
+property.
+
+## Strongly Typed Identifiers
+* [Qowaiv.CodeGeneration.SingleValueObjects](https://github.com/Qowaiv/Qowaiv/blob/master/src/Qowaiv.CodeGeneration.SingleValueObjects/README.md)
+
+## Non-compliant
+``` csharp
+public sealed class MyModel
+{
+    public int Id { get; init; }
+}
+```
+
+## Compliant
+``` csharp
+public sealed class MyModel
+{
+    public MyModelId Id { get; init; }
+}
+```
+or
+``` csharp
+public sealed class MyModel
+{
+    [PrimitiveRequired]
+    public int Id { get; init; }
+}
+```


### PR DESCRIPTION
In code we prefer Strongly Typed ID's over primitives. This is similar to #110. The key difference is - of course - that not all `int`, and `string` properties are ment to be ID's. So based on attributes and naming conventions that decision is made.

Closes #106 